### PR TITLE
Fix TIMOB-18958 Windows: CLI builds hang on first try due to Powershe…

### DIFF
--- a/lib/certs.js
+++ b/lib/certs.js
@@ -83,7 +83,7 @@ function create(appid, certificateFile, options, callback) {
 				appc.subprocess.run(vsInfo.vcvarsall, [
 					'&&',
 					options.powershell || 'powershell',
-					'-command', psScript,
+					'-ExecutionPolicy', 'Bypass', '-File', psScript,
 					appid,
 					moment().add(2, 'years').format('L'),
 					'"' + certPath + '"'

--- a/lib/emulator.js
+++ b/lib/emulator.js
@@ -121,7 +121,9 @@ function isRunning(udid, options, callback) {
 							}
 
 							appc.subprocess.run(options.powershell || 'powershell', [
-								'-command',
+								'-ExecutionPolicy',
+								'Bypass',
+								'-File',
 								script
 							], function (code, out, err) {
 								if (code) {
@@ -429,7 +431,9 @@ function stop(emuHandle, options, callback) {
 							setTimeout(function () {
 								// next get hyper-v to think the emulator is not running
 								appc.subprocess.run(options.powershell || 'powershell', [
-									'-command',
+									'-ExecutionPolicy',
+									'Bypass',
+									'-File',
 									psScript,
 									'"' + emuHandle.name + '"'
 								], function (code, out, err) {

--- a/lib/env.js
+++ b/lib/env.js
@@ -88,7 +88,7 @@ function detect(options, callback) {
 					}
 
 					appc.subprocess.run(options.powershell || 'powershell', [
-						'-command', psScript
+						'-ExecutionPolicy', 'Bypass', '-File', psScript
 					], function (code, out, err) {
 						if (!code && /success/i.test(out.trim().split('\n').shift())) {
 							results.powershell.enabled = true;

--- a/lib/winstore.js
+++ b/lib/winstore.js
@@ -66,14 +66,14 @@ function install(projectDir, options, callback) {
 				return callback(err);
 			}
 
-			appc.subprocess.run(options.powershell || 'powershell', [ '-command', psScript + ' -Force' ], function (code, out, err) {
+			appc.subprocess.run(options.powershell || 'powershell', [ '-ExecutionPolicy', 'Bypass', '-File', psScript + ' -Force' ], function (code, out, err) {
 				if (!code) {
 					emitter.emit('installed');
 					return callback();
 				}
 
 				if (out.indexOf('Please rerun the script without the -Force parameter') !== -1) {
-					appc.subprocess.run(options.powershell || 'powershell', [ '-command', psScript ], function (code, out, err) {
+					appc.subprocess.run(options.powershell || 'powershell', [ '-ExecutionPolicy', 'Bypass', '-File', psScript ], function (code, out, err) {
 						if (err) {
 							emitter.emit('error', err);
 							callback(err);


### PR DESCRIPTION
…ll permission check in windowslib

Use the -ExecutionPolicy Bypass -File args to avoid having to set execution policy manually to run scripts in files.