### PR TITLE
Powershell hang fix, part two

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+0.1.14 (6/25/2015)
+-------------------
+  * More changes related to fixing [TIMOB-18958](https://jira.appcelerator.org/browse/TIMOB-18958) -  Windows: CLI builds hang on first try due to Powershell permission check in windowslib
+
 0.1.13 (6/11/2015)
 -------------------
   * Expand cert utility functionality

--- a/lib/certs.js
+++ b/lib/certs.js
@@ -88,7 +88,8 @@ function create(appid, certificateFile, options, callback) {
 				appc.subprocess.run(vsInfo.vcvarsall, [
 					'&&',
 					options.powershell || 'powershell',
-					'-ExecutionPolicy', 'Bypass', '-File', psScript,
+					'-ExecutionPolicy', 'Bypass', '-NoLogo', '-NonInteractive', '-NoProfile',
+					'-File', psScript,
 					appid,
 					moment().add(2, 'years').format('L'),
 					'"' + certPath + '"'

--- a/lib/emulator.js
+++ b/lib/emulator.js
@@ -121,8 +121,7 @@ function isRunning(udid, options, callback) {
 							}
 
 							appc.subprocess.run(options.powershell || 'powershell', [
-								'-ExecutionPolicy',
-								'Bypass',
+								'-ExecutionPolicy', 'Bypass', '-NoLogo', '-NonInteractive', '-NoProfile',
 								'-File',
 								script
 							], function (code, out, err) {
@@ -431,8 +430,7 @@ function stop(emuHandle, options, callback) {
 							setTimeout(function () {
 								// next get hyper-v to think the emulator is not running
 								appc.subprocess.run(options.powershell || 'powershell', [
-									'-ExecutionPolicy',
-									'Bypass',
+									'-ExecutionPolicy', 'Bypass', '-NoLogo', '-NonInteractive', '-NoProfile',
 									'-File',
 									psScript,
 									'"' + emuHandle.name + '"'

--- a/lib/env.js
+++ b/lib/env.js
@@ -88,7 +88,7 @@ function detect(options, callback) {
 					}
 
 					appc.subprocess.run(options.powershell || 'powershell', [
-						'-ExecutionPolicy', 'Bypass', '-File', psScript
+						'-ExecutionPolicy', 'Bypass', '-NoLogo', '-NonInteractive', '-NoProfile', '-File', psScript
 					], function (code, out, err) {
 						if (!code && /success/i.test(out.trim().split('\n').shift())) {
 							results.powershell.enabled = true;

--- a/lib/winstore.js
+++ b/lib/winstore.js
@@ -72,7 +72,7 @@ function install(projectDir, options, callback) {
 				return callback(err);
 			}
 
-			appc.subprocess.run(options.powershell || 'powershell', ['-ExecutionPolicy', 'Bypass', '-File', psScript, '-Force'], function (code, out, err) {
+			appc.subprocess.run(options.powershell || 'powershell', ['-ExecutionPolicy', 'Bypass', '-NoLogo', '-NonInteractive', '-NoProfile', '-File', psScript, '-Force'], function (code, out, err) {
 				if (!code) {
 					emitter.emit('installed');
 					return callback();
@@ -84,7 +84,7 @@ function install(projectDir, options, callback) {
 				// Error codes 9 and 14 mean rerun without -Force
 				if ((code && (code == 9 || code == 14)) ||
 					out.indexOf('script without the -Force parameter') !== -1) {
-					appc.subprocess.run(options.powershell || 'powershell', ['-ExecutionPolicy', 'Bypass', '-File', psScript], function (code, out, err) {
+					appc.subprocess.run(options.powershell || 'powershell', ['-ExecutionPolicy', 'Bypass', '-NoLogo', '-NonInteractive', '-NoProfile', '-File', psScript], function (code, out, err) {
 						if (err) {
 							emitter.emit('error', err);
 							callback(err);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "windowslib",
-	"version": "0.1.13",
+	"version": "0.1.14",
 	"description": "Windows Phone Utility Library",
 	"keywords": [
 		"appcelerator",


### PR DESCRIPTION
More flags to help avoid the first time powershell subprocess hang. I was still seeing it locally, and am seeing it on the build machine as well.

I was able to reliably reproduce by opening a branch new cmd shell and trying to build an app. That would hang the first time for me. Killing and retrying in that same shell would work.

But with these changes the first ti build after opening a new cmd worked for me.