### PR TITLE
Fix: emulators test failed on Windows 10

### DIFF
--- a/lib/wptool.js
+++ b/lib/wptool.js
@@ -125,10 +125,12 @@ function enumerate(options, callback) {
 					if (err) {
 						// If there was an error, move on, but record error.
 						// Then later if we have no results for any version, we propagate the error
-						results[wpsdk] = {
-							devices: [{name: 'Device', udid: 0, index: 0, wpsdk: null}],
-							emulators: [],
-						};
+						if (!results[wpsdk]) {
+							results[wpsdk] = {
+								devices: [{name: 'Device', udid: 0, index: 0, wpsdk: null}],
+								emulators: [],
+							};
+						}
 						errors.push(err);
 						next();
 					} else {

--- a/lib/wptool.js
+++ b/lib/wptool.js
@@ -29,7 +29,7 @@ const
 	// this is a hard coded list of emulators to detect.
 	// when the next windows phone is released, the enumerate()
 	// function will need to detect the new emulators.
-	wpsdks = ['8.0', '8.1'];
+	wpsdks = ['8.0', '8.1', '10'];
 
 var cache;
 
@@ -132,6 +132,22 @@ function enumerate(options, callback) {
 						errors.push(err);
 						next();
 					} else {
+
+						// TIMOB-19576
+						// Windows 10 Mobile Emulators are detected by 8.1 sdk,
+						// which can be used for both 8.1 and 10 project.
+						if (wpsdk == '8.1') {
+							results['10'] = {
+								devices: [{name: 'Device', udid: 0, index: 0, wpsdk: null}],
+								emulators: []
+							}
+							Object.keys(result.emulators).forEach(function(emu) {
+								if (/Mobile\ Emulator\ 10\./.test(result.emulators[emu].name)) {
+									results['10'].emulators.push(result.emulators[emu]);
+								}
+							});
+						}
+
 						results[wpsdk] = result;
 						next();
 					}

--- a/test/test-emulator.js
+++ b/test/test-emulator.js
@@ -72,8 +72,15 @@ describe('emulator', function () {
 				return done(err);
 			}
 
-			var wpsdk = Object.keys(results.emulators)[0],
-				emu = results.emulators[wpsdk][0];
+			var emu, wpsdk;
+			for (wpsdk in results.emulators) {
+				if (results.emulators[wpsdk].length > 0) {
+					emu = results.emulators[wpsdk][0];
+					break;
+				}
+			}
+
+			should(emu).be.an.Object;
 
 			windowslib.emulator.isRunning(emu.udid, function (err, running) {
 				if (!err && running) {
@@ -104,8 +111,15 @@ describe('emulator', function () {
 				return done(err);
 			}
 
-			var wpsdk = Object.keys(results.emulators)[0],
-				emu = results.emulators[wpsdk][0];
+			var emu, wpsdk;
+			for (wpsdk in results.emulators) {
+				if (results.emulators[wpsdk].length > 0) {
+					emu = results.emulators[wpsdk][0];
+					break;
+				}
+			}
+
+			should(emu).be.an.Object;
 
 			windowslib.emulator.isRunning(emu.udid, function (err, running) {
 				if (err) {
@@ -166,8 +180,12 @@ describe('emulator', function () {
 			function (next) {
 				windowslib.emulator.detect(function (err, results) {
 					if (!err) {
-						wpsdk = Object.keys(results.emulators)[0];
-						emu = results.emulators[wpsdk][0];
+						for (wpsdk in results.emulators) {
+							if (results.emulators[wpsdk].length > 0) {
+								emu = results.emulators[wpsdk][0];
+								break;
+							}
+						}
 					}
 					next(err);
 				});
@@ -233,8 +251,12 @@ describe('emulator', function () {
 			function (next) {
 				windowslib.emulator.detect(function (err, results) {
 					if (!err) {
-						wpsdk = Object.keys(results.emulators)[0];
-						emu = results.emulators[wpsdk][0];
+						for (wpsdk in results.emulators) {
+							if (results.emulators[wpsdk].length > 0) {
+								emu = results.emulators[wpsdk][0];
+								break;
+							}
+						}
 					}
 					next(err);
 				});


### PR DESCRIPTION
Fix unit test failure for `emulator` on Windows 10. It was because `Windows Phone 8.0` sdk returns empty array when you get list of available emulators on Windows 10. I just added array range check in this PR but we might want to just deprecate 8.0 sdk and always prefer 8.1.