### PR TITLE
Fix: visualstudio.detect failed when install path contains space

### DIFF
--- a/lib/visualstudio.js
+++ b/lib/visualstudio.js
@@ -156,6 +156,8 @@ function detect(options, callback) {
 						appc.subprocess.getRealName(info.vcvarsall, function (err, vcvarsall) {
 							if (!err) {
 								info.vcvarsall = vcvarsall;
+								// vcvarsall may contain space
+								vcvarsall = vcvarsall.replace(/\ /g, '^ ');
 
 								// now that we have vcvarsall, get the msbuild version
 								appc.subprocess.run('cmd', [ '/C', vcvarsall + ' && MSBuild /version' ], function (code, out, err) {


### PR DESCRIPTION
`visualstudio.detect` failed when install path contains space. I saw `vcvarsall` contains space for Visual Studio 2015 on Windows 8.1, which is installed into the default location (C:\Program Files (x86)\Microsoft Visual Studio 14.0). Interestingly `vcvarsall` for Visual Studio 2013 does not contains space at the time. Either way it's safer to always escape the space.