### PR TITLE
Remove error message for Windows Store deploy command

### DIFF
--- a/lib/winstore.js
+++ b/lib/winstore.js
@@ -344,16 +344,6 @@ function detect(options, callback) {
 					return finalize();
 				}
 
-				if (Object.keys(results.windows).every(function (v) { return !results.windows[v].deployCmd; })) {
-					results.issues.push({
-						id: 'WINDOWS_STORE_SDK_MISSING_DEPLOY_CMD',
-						type: 'error',
-						message: __('Microsoft Windows Store SDK is missing the deploy command.') + '\n' +
-						__('You will be unable to build Windows Store apps.')
-					});
-					return finalize();
-				}
-
 				var preferred = options.preferred;
 				if (!results.windows[preferred] || !results.windows[preferred].supported) {
 					preferred = Object.keys(results.windows).filter(function (v) { return results.windows[v].supported; }).sort().pop();


### PR DESCRIPTION
Remove deploy command check at winstore.deploy because `deployCmd` is not actually used for Windows Store apps. This also removes `Windows Store SDK is missing the deploy command` error message at `appc setup` on Windows, which is not quite right.

```
$ appc setup
...
The following WINDOWS issues were found in your environment:

        Microsoft Windows Store SDK is missing the deploy command.
        You will be unable to build Windows Store apps.

Some issues were detected for your environment

        Please review the above found issues that were detected for your environment.
        You should resolve these issues before building or running a cross platform app.
        You can re-run setup once they are resolved to validate.

appc setup complete!
```