### PR TITLE
Fix: winstore.launch doesn't launch on Windows 10

### DIFF
--- a/lib/certs.js
+++ b/lib/certs.js
@@ -85,7 +85,7 @@ function create(appid, certificateFile, options, callback) {
 				}
 
 				// first lets create the cert
-				appc.subprocess.run(vsInfo.vcvarsall, [
+				appc.subprocess.run(vsInfo.vcvarsall.replace(/\ /g, '^ '), [
 					'&&',
 					options.powershell || 'powershell',
 					'-ExecutionPolicy', 'Bypass', '-NoLogo', '-NonInteractive', '-NoProfile',

--- a/lib/visualstudio.js
+++ b/lib/visualstudio.js
@@ -289,7 +289,7 @@ function build(options, callback) {
 				callback: callback
 			} ];
 
-			appc.subprocess.run(vsInfo.vcvarsall, [
+			appc.subprocess.run(vsInfo.vcvarsall.replace(/\ /g, '^ '), [
 				'&&', 'MSBuild', '/m', '/t:rebuild', '/p:configuration=' + (options.buildConfiguration || 'Release'), options.project
 			], function (code, out, err) {
 				var queue = runningBuilds[options.project];

--- a/lib/winstore.js
+++ b/lib/winstore.js
@@ -176,9 +176,17 @@ function launch(appId, options, callback) {
 		var wstool = path.resolve(__dirname, '..', 'bin', 'wstool.exe');
 
 		function runTool() {
-			var args = ['launch', appId];
+			var args = ['launch', '--appid', appId];
 
-			options.version && args.push(options.version);
+			if (options.version) {
+				args.push('--version');
+				args.push(options.version);
+			}
+
+			if (options.windowsAppId) {
+				args.push('--windowsAppId');
+				args.push(options.windowsAppId);
+			}
 
 			appc.subprocess.run(wstool, args, function (code, out, err) {
 				if (code) {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
 		"test-process": "mocha --require test/init --reporter spec --check-leaks test/test-process",
 		"test-visualstudio": "mocha --require test/init --reporter spec --check-leaks test/test-visualstudio",
 		"test-windowsphone": "mocha --require test/init --reporter spec --check-leaks test/test-windowsphone",
+		"test-winstore": "mocha --require test/init --reporter spec --check-leaks test/test-winstore",
 		"test-wptool": "mocha --require test/init --reporter spec --check-leaks test/test-wptool"
 	},
 	"engines": {

--- a/test/test-winstore.js
+++ b/test/test-winstore.js
@@ -18,6 +18,16 @@ describe('winstore', function () {
 		should(windowslib.winstore).be.an.Object;
 	});
 
+	it.skip('launch should launch Windows Store App', function (done) {
+		this.timeout(10000);
+		this.slow(2000);
+
+		var appid = 'com.appcelerator.launch.test',
+			opts  = { windowsAppId: 'App' };
+
+		windowslib.winstore.launch(appid, opts, done);
+	});
+
 	(process.platform === 'win32' ? it : it.skip)('detect should find Windows Store SDK installations', function (done) {
 		this.timeout(5000);
 		this.slow(2000);

--- a/wstool/wstool.cs
+++ b/wstool/wstool.cs
@@ -10,39 +10,53 @@ namespace wstool
 				return showHelp();
 			}
 
-			string command = null;
-			int i;
+			string command = args[0];
 
-			for (i = 0; i < args.Length; i++) {
-				if (command == null) {
-					command = args[i];
-					if (args[i] == "launch") {
-						if (i + 1 < args.Length) {
-							string appid = args[++i];
-							string version = i + 1 < args.Length ? args[++i] : null;
-							return launchApp(appid, version);
-						} else {
-							return showHelp("Missing app id.");
-						}
+			if (command == "launch") {
+				string appid    = null;
+				string version  = null;
+				string windowsAppId = null;
+				for (var i = 1; i < args.Length; i++)  {
+					string option = args[i++];
+					if (args.Length <= i || args[i].StartsWith("--")) {
+						return showHelp(String.Format("Invalid option for command '{0}'", command));
 					}
+					switch (option) {
+						case "--appid":
+							appid = args[i];
+							break;
+						case "--version":
+							version = args[i];
+							break;
+						case "--windowsAppId":
+							windowsAppId = args[i];
+							break;
+						default:
+							return showHelp(String.Format("Invalid option for command '{0}'", command));
+					}
+
 				}
+				if (appid == null) {
+					return showHelp(String.Format("Invalid option for command '{0}'", command));
+				}
+
+				return launchApp(appid, version, windowsAppId);
 			}
 
-			if (command != null) {
-				return showHelp(String.Format("Invalid command '{0}'", command));
-			}
-
-			return showHelp();
+			return showHelp(String.Format("Invalid command '{0}'", command));
 		}
 
-		static int launchApp(String appid, String version) {
-			String appUserModelId = null;
+		static int launchApp(String appid, String version, String windowsAppId) {
+			string appUserModelId = null;
+			string windowsAppName = null;
 			var appListKey = Registry.CurrentUser.OpenSubKey("Software\\Classes\\ActivatableClasses\\Package");
 
 			// if we have the version, then this should be simple
 			if (version != null) {
 				foreach (var appKeyName in appListKey.GetSubKeyNames()) {
 					if (appKeyName.IndexOf(appid + "_" + version + "_") == 0) {
+						// Save the name, in case sub key doesn't exist 
+						windowsAppName = appKeyName;
 						var appKey = appListKey.OpenSubKey(appKeyName);
 						var appClassKey = appKey.OpenSubKey("ActivatableClassId\\App");
 						if (appClassKey == null)
@@ -65,17 +79,23 @@ namespace wstool
 						if (q != -1) {
 							string thisVersion = appKeyName.Substring(p + 1, q);
 							if (lastVersion == null || String.Compare(thisVersion, lastVersion, true) > 0) {
+								// Save the name, in case sub key doesn't exist 
+								windowsAppName = appKeyName;
 								var appKey = appListKey.OpenSubKey(appKeyName);
 								var appClassKey = appKey.OpenSubKey("ActivatableClassId\\App");
 								if (appClassKey == null)
 								{
 									appClassKey = appKey.OpenSubKey("ActivatableClassId\\App.wwa");
 								}
-								String serverId = (String)appClassKey.GetValue("Server");
-								var subKey = appKey.OpenSubKey("Server\\" + serverId);
-								if (subKey != null) {
-									appUserModelId = (String)subKey.GetValue("AppUserModelId");
-									lastVersion = thisVersion;
+								if (appClassKey != null)
+								{
+									String serverId = (String)appClassKey.GetValue("Server");
+									var subKey = appKey.OpenSubKey("Server\\" + serverId);
+									if (subKey != null)
+									{
+										appUserModelId = (String)subKey.GetValue("AppUserModelId");
+										lastVersion = thisVersion;
+									}
 								}
 							}
 						}
@@ -83,14 +103,38 @@ namespace wstool
 				}
 			}
 
+			// If there's no Server entry in the registry...we still have a way when Windows Store application id is provided
+			// You can find Windows Store application id in the "Application Id" value in the AppxManifest.xml.
+			if (appUserModelId == null && windowsAppName != null) {
+
+				// Extract "family name" from the entry name, by removing version and archtecture string
+				// For example: Microsoft.SkypeApp_3.2.1.0_x86__kzf8qxf38zg5c -> Microsoft.SkypeApp_kzf8qxf38zg5c
+				var first = windowsAppName.IndexOf("_");
+				var last  = windowsAppName.LastIndexOf("_");
+				var familyName = windowsAppName.Substring(0, first) + "_" + windowsAppName.Substring(last + 1);
+
+				// we try to do our best...many apps are actually using "App" for application id
+				if (windowsAppId == null) {
+					windowsAppId = "App";
+				}
+				
+				// then we conbine it with the Windows Store application id...wish it generates valid one
+				appUserModelId = String.Format("{0}!{1}", familyName, windowsAppId);
+			}
+
 			if (appUserModelId == null) {
 				Console.WriteLine("Could not find version " + version + " of application " + appid + " in the registry. Is the application installed?");
 				return 1;
 			}
 
-			var aam = new ApplicationActivationManager();
-			UInt32 id;
-			aam.ActivateApplication(appUserModelId, null, ActivateOptions.None, out id);
+			try {
+				var aam = new ApplicationActivationManager();
+				UInt32 id;
+				aam.ActivateApplication(appUserModelId, null, ActivateOptions.None, out id);
+			} catch (System.Runtime.InteropServices.COMException) {
+				Console.WriteLine("Could not find version " + version + " of application " + appid + " in the registry. Is the application installed?");
+				return 1;
+			}
 
 			return 0;
 		}
@@ -106,7 +150,7 @@ namespace wstool
 			Console.WriteLine("  wstool <command> [options]");
 			Console.WriteLine("");
 			Console.WriteLine("Commands:");
-			Console.WriteLine("  launch <appid> [<version>]   Launch a Windows Store app");
+			Console.WriteLine("  launch --appid <Titanium application id> [--appversion <version>] [--windowsAppId <Windows Store application id>] Launch a Windows Store app");
 			Console.WriteLine("");
 
 			return msg.Length > 0 ? 1 : 0;


### PR DESCRIPTION
Fix for [TIMOB-19693](https://jira.appcelerator.org/browse/TIMOB-19693).

- Fix: `vsInfo.vcvarsall` should escape space when command is used with `&&`
- Fix: `winstore.launch` doesn't launch Windows 10 Store app
