### PR TITLE
Fix: escape vcvarsall before subprocess.run

### DIFF
--- a/lib/certs.js
+++ b/lib/certs.js
@@ -203,7 +203,7 @@ function generate(subjectName, certificateFile, options, callback) {
 				'-e', expirationDate, '-sv', pvk, cer
 			];
 
-			appc.subprocess.run(vsInfo.vcvarsall, args, function (code, out, err) {
+			appc.subprocess.run(vsInfo.vcvarsall.replace(/\ /g, '^ '), args, function (code, out, err) {
 				if (code) {
 					var ex = new Error(__('Failed to create certificate (code %s)', code));
 					emitter.emit('error', ex);
@@ -287,7 +287,7 @@ function generatePFX(privateKeyFile, certificateFile, pfxDestinationFile, passwo
 			}
 
 			// package the certificate as pfx
-			appc.subprocess.run(vsInfo.vcvarsall, args, function (code, out, err) {
+			appc.subprocess.run(vsInfo.vcvarsall.replace(/\ /g, '^ '), args, function (code, out, err) {
 				if (code) {
 					var ex = new Error(__('Failed to convert certificate to pfx (code %s)', code));
 					emitter.emit('error', ex);

--- a/lib/visualstudio.js
+++ b/lib/visualstudio.js
@@ -290,7 +290,7 @@ function build(options, callback) {
 			} ];
 
 			appc.subprocess.run(vsInfo.vcvarsall.replace(/\ /g, '^ '), [
-				'&&', 'MSBuild', '/m', '/t:rebuild', '/p:configuration=' + (options.buildConfiguration || 'Release'), options.project
+				'&&', 'MSBuild', '/t:rebuild', '/p:configuration=' + (options.buildConfiguration || 'Release'), options.project
 			], function (code, out, err) {
 				var queue = runningBuilds[options.project];
 				delete runningBuilds[options.project];


### PR DESCRIPTION
- Fix: Make sure to escape `vcvarsall` at `subprocess.run`
- Fix: Stop using /m at msbuild

Spaces in `vcvarsall` should be escaped in `subprocess.run` when it is used with `&&`, it may cause error when both Visual Studio 2013 and 2015 are installed. Also, stop using `/m` at MsBuild due to [TIMOB-19646](https://jira.appcelerator.org/browse/TIMOB-19646).

@sgtcoolguy, could you bump up the version and update [titanium_mobile](https://github.com/appcelerator/titanium_mobile) so that it points to the new version? Thanks.