### PR TITLE
Fixes for Windows 10 Phone

### DIFF
--- a/lib/windowsphone.js
+++ b/lib/windowsphone.js
@@ -52,6 +52,10 @@ function detect(options, callback) {
 			searchPaths = [
 				'HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Microsoft SDKs\\WindowsPhone', // probably nothing here
 				'HKEY_LOCAL_MACHINE\\Software\\Wow6432Node\\Microsoft\\Microsoft SDKs\\WindowsPhone' // this is most likely where WPSDK will be found
+			],
+			win10SearchPaths = [
+				'HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Microsoft SDKs\\Windows\\v10.0', // probably nothing here
+				'HKEY_LOCAL_MACHINE\\Software\\Wow6432Node\\Microsoft\\Microsoft SDKs\\Windows\\v10.0' // this is most likely where Windows SDK will be found
 			];
 
 		function finalize() {
@@ -150,6 +154,34 @@ function detect(options, callback) {
 					});
 					return finalize();
 				}
+
+				// Win 10, which currently requires the 8.1 deploy cmd!
+				async.each(win10SearchPaths, function (keyPath, next) {
+					appc.subprocess.run('reg', ['query', keyPath], function (code, out, err) {
+						if (!code) {
+							var version = '10.0';
+							// get only the values we are interested in
+							out.trim().split(/\r\n|\n/).forEach(function (line) {
+								var parts = line.trim().split('   ').map(function (p) { return p.trim(); });
+								if (parts.length == 3) {
+									if (parts[0] == 'InstallationFolder') {
+										results.windowsphone || (results.windowsphone = {});
+										results.windowsphone[version] = {
+											version: version,
+											registryKey: keyPath,
+											supported: !options.supportedWindowsPhoneSDKVersions || appc.version.satisfies(version, options.supportedWindowsPhoneSDKVersions, false), // no maybes
+											path: parts[2],
+											deployCmd: results.windowsphone['8.1'] ? results.windowsphone['8.1'].deployCmd : null,
+											xapSignTool: results.windowsphone['8.1'] ? results.windowsphone['8.1'].xapSignTool : null,
+											selected: false
+										};
+									}
+								}
+							});
+						}
+						next();
+					});
+				});
 
 				var preferred = options.preferred;
 				if (!results.windowsphone[preferred] || !results.windowsphone[preferred].supported) {

--- a/lib/wptool.js
+++ b/lib/wptool.js
@@ -29,7 +29,7 @@ const
 	// this is a hard coded list of emulators to detect.
 	// when the next windows phone is released, the enumerate()
 	// function will need to detect the new emulators.
-	wpsdks = ['8.0', '8.1', '10'];
+	wpsdks = ['8.0', '8.1', '10.0'];
 
 var cache;
 
@@ -104,7 +104,7 @@ function enumerate(options, callback) {
 						{
 							emulators.push({name: match[2], udid: wpsdk.replace('.', '-') + "-" + match[1], index: parseInt(match[1]), wpsdk: wpsdk});
 						}
-						
+
 						next(null, {
 							devices: [{name: 'Device', udid: 0, index: 0, wpsdk: null}],
 							emulators: emulators,
@@ -138,16 +138,12 @@ function enumerate(options, callback) {
 						// TIMOB-19576
 						// Windows 10 Mobile Emulators are detected by 8.1 sdk,
 						// which can be used for both 8.1 and 10 project.
-						if (wpsdk == '8.1') {
-							results['10'] = {
-								devices: [{name: 'Device', udid: 0, index: 0, wpsdk: null}],
-								emulators: []
-							}
-							Object.keys(result.emulators).forEach(function(emu) {
-								if (/Mobile\ Emulator\ 10\./.test(result.emulators[emu].name)) {
-									results['10'].emulators.push(result.emulators[emu]);
-								}
+						if (wpsdk != '8.0') {
+							// limit 8.1 or 10.0 emulators to those SDKs only
+							result.emulators = result.emulators.filter(function (e) {
+								return new RegExp("Emulator\ " + wpsdk).test(e.name);
 							});
+							// FIXME change the udids back if they don't start at 1? (If we have 8.1 and 10, the 8.1 emulators udids start at 8-1-7)
 						}
 
 						results[wpsdk] = result;
@@ -162,7 +158,7 @@ function enumerate(options, callback) {
 					emitter.emit('error', errors[0]);
 					return callback(errors[0]);
 				}
-				
+
 				// add a helper function to get a device by udid
 				Object.defineProperty(results, 'getByUdid', {
 					value: function (udid) {


### PR DESCRIPTION
- Only list the 8.1 emulators for 8.1 and 10.0 for 10.0 SDKs.
- Detect Windows 10 mobile details (sort of)
  - for now this cheats and uses the 8.1 signtool and deploy command. That's the only way we can get the Win 10 emulator listing. But as [detailed here](https://jira.appcelerator.org/browse/TIMOB-20095) I can't find any way to get an app deployed to the emulator using new or old tooling.