### PR TITLE
Bump to 0.3.0, support Windows 10 detection/usage without requiring 8.1 tooling as well

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+0.3.0 (1/6/2016)
+-------------------
+  * Support detection and use of Windows 10 SDK/tooling without requiring 8.1 tools installed.
+
 0.2.2 (12/14/2015)
 -------------------
   * Better error messages about bad app GUIDs when launching using our custom wptool

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
  * Main namespace for the windowslib.
  *
  * @copyright
- * Copyright (c) 2014-2015 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2014-2016 by Appcelerator, Inc. All Rights Reserved.
  *
  * @license
  * Licensed under the terms of the Apache Public License.
@@ -14,6 +14,7 @@ const
 	async        = require('async'),
 	EventEmitter = require('events').EventEmitter,
 	magik        = require('./lib/utilities').magik,
+	mix          = require('./lib/utilities').mix,
 	__           = appc.i18n(__dirname).__,
 
 	packageJson  = require('./package.json'),
@@ -63,25 +64,6 @@ function detect(options, callback) {
 			detectVersion: '3.0',
 			issues: []
 		};
-
-		function mix(src, dest) {
-			Object.keys(src).forEach(function (name) {
-				if (Array.isArray(src[name])) {
-					if (Array.isArray(dest[name])) {
-						dest[name] = dest[name].concat(src[name]);
-					} else {
-						dest[name] = src[name];
-					}
-				} else if (src[name] !== null && typeof src[name] === 'object') {
-					dest[name] || (dest[name] = {});
-					Object.keys(src[name]).forEach(function (key) {
-						dest[name][key] = src[name][key];
-					});
-				} else {
-					dest[name] = src[name];
-				}
-			});
-		}
 
 		async.each([env, visualstudio, windowsphone, assemblies, device, winstore, emulator], function (lib, next) {
 			lib.detect(options, function (err, result) {

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -50,3 +50,22 @@ exports.magik = function magik(options, callback, body) {
 
 	return emitter;
 };
+
+exports.mix = function mix(src, dest) {
+	Object.keys(src).forEach(function (name) {
+		if (Array.isArray(src[name])) {
+			if (Array.isArray(dest[name])) {
+				dest[name] = dest[name].concat(src[name]);
+			} else {
+				dest[name] = src[name];
+			}
+		} else if (src[name] !== null && typeof src[name] === 'object') {
+			dest[name] || (dest[name] = {});
+			Object.keys(src[name]).forEach(function (key) {
+				dest[name][key] = src[name][key];
+			});
+		} else {
+			dest[name] = src[name];
+		}
+	});
+};

--- a/lib/windowsphone.js
+++ b/lib/windowsphone.js
@@ -4,7 +4,7 @@
  * @module windowsphone
  *
  * @copyright
- * Copyright (c) 2009-2015 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2009-2016 by Appcelerator, Inc. All Rights Reserved.
  *
  * @license
  * Licensed under the terms of the Apache Public License
@@ -16,6 +16,7 @@ const
 	async = require('async'),
 	fs = require('fs'),
 	magik = require('./utilities').magik,
+	mix = require('./utilities').mix,
 	path = require('path'),
 	__ = appc.i18n(__dirname).__;
 
@@ -23,6 +24,153 @@ var detectCache,
 	deviceCache = {};
 
 exports.detect = detect;
+
+/**
+ * Detects Windows Phone SDKs 8.0/8.1.
+ * @param {Object} [options] - An object containing various settings.
+ * @param {Boolean} [options.bypassCache=false] - When true, re-detects the Windows Phone SDKs.
+ * @param {String} [options.preferredWindowsPhoneSDK] - The preferred version of the Windows Phone SDK to use by default. Example "8.0".
+ * @param {String} [options.supportedWindowsPhoneSDKVersions] - A string with a version number or range to check if a Windows Phone SDK is supported.
+ * @param {Function} [callback(err, results)] - A function to call with the Windows Phone SDK information.
+ */
+function detectLegacy(options, callback) {
+	var results = {
+			windowsphone: {},
+			issues: []
+		},
+		searchPaths = [
+			'HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Microsoft SDKs\\WindowsPhone', // probably nothing here
+			'HKEY_LOCAL_MACHINE\\Software\\Wow6432Node\\Microsoft\\Microsoft SDKs\\WindowsPhone' // this is most likely where WPSDK will be found
+		];
+
+	async.each(searchPaths, function (keyPath, next) {
+		appc.subprocess.run('reg', ['query', keyPath], function (code, out, err) {
+			var keyRegExp = /.+\\(v\d+\.\d)$/;
+			if (!code) {
+				out.trim().split(/\r\n|\n/).forEach(function (key) {
+					key = key.trim();
+					var m = key.match(keyRegExp),
+						version = m[1].replace(/^v/, '');
+					if (m) {
+						results.windowsphone || (results.windowsphone = {});
+						results.windowsphone[version] = {
+							version: version,
+							registryKey: keyPath + '\\' + m[1],
+							supported: !options.supportedWindowsPhoneSDKVersions || appc.version.satisfies(version, options.supportedWindowsPhoneSDKVersions, false), // no maybes
+							path: null,
+							deployCmd: null,
+							xapSignTool: null,
+							selected: false
+						};
+					}
+				});
+			}
+			next();
+		});
+	}, function () {
+		// check if we didn't find any Windows Phone SDKs, then we're done
+		if (!Object.keys(results.windowsphone).length) {
+			return callback(null, results);
+		}
+
+		// fetch Windows Phone SDK install information
+		async.each(Object.keys(results.windowsphone), function (ver, next) {
+			appc.subprocess.run('reg', ['query', results.windowsphone[ver].registryKey + '\\Install Path', '/v', '*'], function (code, out, err) {
+				if (code) {
+					// bad key? either way, remove this version
+					delete results.windowsphone[ver];
+				} else {
+					// get only the values we are interested in
+					out.trim().split(/\r\n|\n/).forEach(function (line) {
+						var parts = line.trim().split('   ').map(function (p) { return p.trim(); });
+						if (parts.length == 3) {
+							if (parts[0] == 'Install Path') {
+								results.windowsphone[ver].path = parts[2];
+
+								var deployCmd = path.join(parts[2], 'Tools', 'XAP Deployment', 'XapDeployCmd.exe');
+								// check the old WP8 location
+								if (fs.existsSync(deployCmd)) {
+									results.windowsphone[ver].deployCmd = deployCmd;
+								// check the new WP8.1 location
+								} else if (fs.existsSync(deployCmd = path.join(parts[2], 'Tools', 'AppDeploy', 'AppDeployCmd.exe'))) {
+									results.windowsphone[ver].deployCmd = deployCmd;
+								} else {
+									// no deploy command! For now, mark unsupported!
+									results.windowsphone[ver].supported = false;
+								}
+
+								var xapSignTool = path.join(parts[2], 'Tools', 'XapSignTool', 'XapSignTool.exe');
+								if (fs.existsSync(xapSignTool)) {
+									results.windowsphone[ver].xapSignTool = xapSignTool;
+								}
+							}
+						}
+					});
+				}
+				next();
+			});
+		}, function () {
+			callback(null, results);
+		});
+	});
+};
+
+/**
+ * Detects Windows 10 SDK.
+ * @param {Object} [options] - An object containing various settings.
+ * @param {Boolean} [options.bypassCache=false] - When true, re-detects the Windows Phone SDKs.
+ * @param {String} [options.preferredWindowsPhoneSDK] - The preferred version of the Windows Phone SDK to use by default. Example "8.0".
+ * @param {String} [options.supportedWindowsPhoneSDKVersions] - A string with a version number or range to check if a Windows Phone SDK is supported.
+ * @param {Function} [callback(err, results)] - A function to call with the Windows Phone SDK information.
+ */
+function detectWin10(options, callback) {
+	var results = {
+			windowsphone: {},
+			issues: []
+		},
+		win10SearchPaths = [
+			'HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Microsoft SDKs\\Windows\\v10.0', // probably nothing here
+			'HKEY_LOCAL_MACHINE\\Software\\Wow6432Node\\Microsoft\\Microsoft SDKs\\Windows\\v10.0' // this is most likely where Windows SDK will be found
+		];
+
+	async.each(win10SearchPaths, function (keyPath, next) {
+		appc.subprocess.run('reg', ['query', keyPath], function (code, out, err) {
+			if (!code) {
+				var version = '10.0';
+				// get only the values we are interested in
+				out.trim().split(/\r\n|\n/).forEach(function (line) {
+					var parts = line.trim().split('   ').map(function (p) { return p.trim(); });
+					if (parts.length == 3) {
+						if (parts[0] == 'InstallationFolder') {
+							results.windowsphone || (results.windowsphone = {});
+							results.windowsphone[version] = {
+								version: version,
+								registryKey: keyPath,
+								supported: !options.supportedWindowsPhoneSDKVersions || appc.version.satisfies(version, options.supportedWindowsPhoneSDKVersions, false), // no maybes
+								path: parts[2],
+								deployCmd: null,
+								xapSignTool: null,
+								selected: false
+							};
+
+							var deployCmd = path.join(parts[2], 'bin', 'x86', 'WinAppDeployCmd.exe'),
+								signTool = path.join(parts[2], 'bin', 'x86', 'signtool.exe');
+							if (fs.existsSync(deployCmd)) {
+								results.windowsphone[version].deployCmd = deployCmd;
+							}
+							if (fs.existsSync(signTool)) {
+								results.windowsphone[version].xapSignTool = signTool;
+							}
+						}
+					}
+				});
+			}
+			next();
+		});
+	}, function () {
+		callback(null, results);
+	});
+};
 
 /**
  * Detects Windows Phone SDKs.
@@ -48,15 +196,7 @@ function detect(options, callback) {
 		var results = {
 				windowsphone: {},
 				issues: []
-			},
-			searchPaths = [
-				'HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Microsoft SDKs\\WindowsPhone', // probably nothing here
-				'HKEY_LOCAL_MACHINE\\Software\\Wow6432Node\\Microsoft\\Microsoft SDKs\\WindowsPhone' // this is most likely where WPSDK will be found
-			],
-			win10SearchPaths = [
-				'HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Microsoft SDKs\\Windows\\v10.0', // probably nothing here
-				'HKEY_LOCAL_MACHINE\\Software\\Wow6432Node\\Microsoft\\Microsoft SDKs\\Windows\\v10.0' // this is most likely where Windows SDK will be found
-			];
+			};
 
 		function finalize() {
 			detectCache = results;
@@ -64,76 +204,19 @@ function detect(options, callback) {
 			callback(null, results);
 		}
 
-		async.each(searchPaths, function (keyPath, next) {
-			appc.subprocess.run('reg', ['query', keyPath], function (code, out, err) {
-				var keyRegExp = /.+\\(v\d+\.\d)$/;
-				if (!code) {
-					out.trim().split(/\r\n|\n/).forEach(function (key) {
-						key = key.trim();
-						var m = key.match(keyRegExp),
-							version = m[1].replace(/^v/, '');
-						if (m) {
-							results.windowsphone || (results.windowsphone = {});
-							results.windowsphone[version] = {
-								version: version,
-								registryKey: keyPath + '\\' + m[1],
-								supported: !options.supportedWindowsPhoneSDKVersions || appc.version.satisfies(version, options.supportedWindowsPhoneSDKVersions, false), // no maybes
-								path: null,
-								deployCmd: null,
-								xapSignTool: null,
-								selected: false
-							};
-						}
-					});
+		// Detect 8.0/8.1 and 10.0 in parallel
+		async.parallel([
+				function (next) {
+					detectLegacy(options, next);
+				},
+				function (next) {
+					detectWin10(options, next);
 				}
-				next();
-			});
-		}, function () {
-			// check if we didn't find any Windows Phone SDKs, then we're done
-			if (!Object.keys(results.windowsphone).length) {
-				results.issues.push({
-					id: 'WINDOWS_PHONE_SDK_NOT_INSTALLED',
-					type: 'error',
-					message: __('Microsoft Windows Phone SDK not found.') + '\n' +
-						__('You will be unable to build Windows Phone apps.')
-				});
-				return finalize();
-			}
+			], function (err, detectResults) {
+				// combine the results objects from 8.0/8.1 and 10.0!
+				mix(detectResults[0], results);
+				mix(detectResults[1], results);
 
-			// fetch Windows Phone SDK install information
-			async.each(Object.keys(results.windowsphone), function (ver, next) {
-				appc.subprocess.run('reg', ['query', results.windowsphone[ver].registryKey + '\\Install Path', '/v', '*'], function (code, out, err) {
-					if (code) {
-						// bad key? either way, remove this version
-						delete results.windowsphone[ver];
-					} else {
-						// get only the values we are interested in
-						out.trim().split(/\r\n|\n/).forEach(function (line) {
-							var parts = line.trim().split('   ').map(function (p) { return p.trim(); });
-							if (parts.length == 3) {
-								if (parts[0] == 'Install Path') {
-									results.windowsphone[ver].path = parts[2];
-
-									var deployCmd = path.join(parts[2], 'Tools', 'XAP Deployment', 'XapDeployCmd.exe');
-									// check the old WP8 location
-									if (fs.existsSync(deployCmd)) {
-										results.windowsphone[ver].deployCmd = deployCmd;
-									// check the new WP8.1 location
-									} else if (fs.existsSync(deployCmd = path.join(parts[2], 'Tools', 'AppDeploy', 'AppDeployCmd.exe'))) {
-										results.windowsphone[ver].deployCmd = deployCmd;
-									}
-
-									var xapSignTool = path.join(parts[2], 'Tools', 'XapSignTool', 'XapSignTool.exe');
-									if (fs.existsSync(xapSignTool)) {
-										results.windowsphone[ver].xapSignTool = xapSignTool;
-									}
-								}
-							}
-						});
-					}
-					next();
-				});
-			}, function () {
 				// double check if we didn't find any Windows Phone SDKs, then we're done
 				if (Object.keys(results.windowsphone).every(function (v) { return !results.windowsphone[v].path; })) {
 					results.issues.push({
@@ -155,53 +238,16 @@ function detect(options, callback) {
 					return finalize();
 				}
 
-				// Win 10, which currently requires the 8.1 deploy cmd!
-				async.each(win10SearchPaths, function (keyPath, next) {
-					appc.subprocess.run('reg', ['query', keyPath], function (code, out, err) {
-						if (!code) {
-							var version = '10.0';
-							// get only the values we are interested in
-							out.trim().split(/\r\n|\n/).forEach(function (line) {
-								var parts = line.trim().split('   ').map(function (p) { return p.trim(); });
-								if (parts.length == 3) {
-									if (parts[0] == 'InstallationFolder') {
-										results.windowsphone || (results.windowsphone = {});
-										results.windowsphone[version] = {
-											version: version,
-											registryKey: keyPath,
-											supported: !options.supportedWindowsPhoneSDKVersions || appc.version.satisfies(version, options.supportedWindowsPhoneSDKVersions, false), // no maybes
-											path: parts[2],
-											deployCmd: null,
-											xapSignTool: null,
-											selected: false
-										};
+				var preferred = options.preferred;
+				if (!results.windowsphone[preferred] || !results.windowsphone[preferred].supported) {
+					preferred = Object.keys(results.windowsphone).filter(function (v) { return results.windowsphone[v].supported; }).sort().pop();
+				}
+				if (preferred) {
+					results.windowsphone[preferred].selected = true;
+				}
 
-										var deployCmd = path.join(parts[2], 'bin', 'x86', 'WinAppDeployCmd.exe'),
-											signTool = path.join(parts[2], 'bin', 'x86', 'signtool.exe');
-										if (fs.existsSync(deployCmd)) {
-											results.windowsphone[version].deployCmd = deployCmd;
-										}
-										if (fs.existsSync(signTool)) {
-											results.windowsphone[version].xapSignTool = signTool;
-										}
-									}
-								}
-							});
-						}
-						next();
-					});
-				}, function () {
-					var preferred = options.preferred;
-					if (!results.windowsphone[preferred] || !results.windowsphone[preferred].supported) {
-						preferred = Object.keys(results.windowsphone).filter(function (v) { return results.windowsphone[v].supported; }).sort().pop();
-					}
-					if (preferred) {
-						results.windowsphone[preferred].selected = true;
-					}
-
-					finalize();
-				});
-			});
-		});
+				finalize();
+			}
+		);
 	});
 };

--- a/lib/wptool.js
+++ b/lib/wptool.js
@@ -82,19 +82,20 @@ function wptoolEnumerate(wpsdk, options, next) {
 			return next(ex);
 		}
 
+		// TODO Handle when we don't have permissions to the folders in SDK and need to offload build to user HOME
 		fs.stat(wptool, function (err, stats) {
 			if (err) {
-			    // file does not exist, build the tool and then run
-			    if (err.code === 'ENOENT') {
+				// file does not exist, build the tool and then run
+				if (err.code === 'ENOENT') {
 					return buildWpTool(options, function (err, path) {
-	    				if (err) {
-	    					return next(err);
-	    				}
-	    				run(wpsdk, next);
-	    			});
-			    }
+						if (err) {
+							return next(err);
+						}
+						run(wpsdk, next);
+					});
+				}
 				// some other error
-			    return next(err);
+				return next(err);
 			}
 
 			// Compare modified time versus wptool.cs!
@@ -322,7 +323,7 @@ function connect(udid, options, callback) {
 					return callback(err);
 				}
 				// TODO if we have win 10 use it's deploy tool to push to devices?
-				var wpsdk = dev.wpsdk || '8.1',
+				var wpsdk = dev.wpsdk || options.wpsdk || options.preferredWindowsPhoneSDK || '8.1',
 					done = function (err, result) {
 						if (err) {
 							emitter.emit(result || 'error', err);
@@ -351,6 +352,9 @@ function connect(udid, options, callback) {
  * @param {Function} [callback(err, path)] - A function to call after building the executable.
  */
 function buildWpTool(options, callback) {
+	// FIXME Handle when we don't have permission to edit the existing csproj or copy to the bin dir!
+	// We should move to a writable directory under HOME and return path to that
+
 	// find required assemblies
 	return assemblies.detect(options, function (err, results) {
 		if (err) {
@@ -549,7 +553,7 @@ function nativeLaunch(device, appid, options, callback) {
 			return callback(err);
 		}
 
-		var wpsdk = device.wpsdk || '8.1',
+		var wpsdk = device.wpsdk || options.wpsdk || options.preferredWindowsPhoneSDK || '8.1',
 			deployCmd = phoneResults.windowsphone[wpsdk].deployCmd,
 			args = [
 				'/launch',
@@ -730,7 +734,7 @@ function install(device, appPath, options, callback) {
 				return callback(err);
 			}
 
-			var wpsdk = device.wpsdk || options.wpsdk || '8.1',
+			var wpsdk = device.wpsdk || options.wpsdk || options.preferredWindowsPhoneSDK || '8.1',
 				cmd = phoneResults.windowsphone[wpsdk].deployCmd;
 			if (!cmd) {
 				var ex = new Error(__('Windows Phone SDK v%s does not appear to have an App deploy tool.', wpsdk));
@@ -758,7 +762,7 @@ function install(device, appPath, options, callback) {
 							} else {
 								getProductGUID(appPath, options, function(err, productGuid) {
 									if (err) {
-										emitter.emit(result || 'error', err);
+										emitter.emit('error', err);
 										return next(err);
 									}
 

--- a/lib/wptool.js
+++ b/lib/wptool.js
@@ -5,7 +5,7 @@
  * @module wptool
  *
  * @copyright
- * Copyright (c) 2014-2015 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2014-2016 by Appcelerator, Inc. All Rights Reserved.
  *
  * @license
  * Licensed under the terms of the Apache Public License.
@@ -808,7 +808,7 @@ function install(device, appPath, options, callback) {
 }
 
 /**
- * Unzips an appx file to read the APpxManifest.xml and grab the product guid
+ * Unzips an appx file to read the AppxManifest.xml and grab the product guid
  * out (so we know the guid we need to launch it)
  *
  * @param {String} [appxFile] - Path to the appx, xap or appxbundle to inspect.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "windowslib",
-	"version": "0.2.2",
+	"version": "0.3.0",
 	"description": "Windows Phone Utility Library",
 	"keywords": [
 		"appcelerator",

--- a/test/test-windowsphone.js
+++ b/test/test-windowsphone.js
@@ -2,7 +2,7 @@
  * Tests windowslib's windowsphone module.
  *
  * @copyright
- * Copyright (c) 2014 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2014-2016 by Appcelerator, Inc. All Rights Reserved.
  *
  * @license
  * Licensed under the terms of the Apache Public License.


### PR DESCRIPTION
- We now detect 8.0/8.1 and 10 in parallel. Before we'd look for 8.0/8.1 first and if we didn't find one of those we wouldn't try to get win 10.
- Should be slightly faster detection now because of that?
- Mark 8.1/8.0 supported flag as "false" if we can't find the deploy command, that means by default Windows 10 will be "selected" if we find entries for 8.1 but not the tooling.
- Tested by removing my windows 8.1 SDK/tooling through VS2015 Update 1. It actually keeps some stuff around (like XapSignTool), but removes the AppDeployCmd and in that case we list 8.1 in our entry but as unsupported and 10 is chosen as the preferred/selected.

https://jira.appcelerator.org/browse/TIMOB-20198