### PR TITLE
Enumerate Windows 10 devices using WinAppDeployCmd

### DIFF
--- a/lib/wptool.js
+++ b/lib/wptool.js
@@ -38,6 +38,53 @@ exports.enumerate = enumerate;
 exports.connect = connect;
 exports.install = install;
 
+
+/**
+ * Detects all Windows 10 Mobile devices using WinAppDeployCmd.exe
+ *
+ * @param {String} [deployCmd] - The full path to WinAppDeployCmd.exe
+ * @param {Function} [next(err, results)] - A function to call with the device information.
+ */
+function winAppDeployCmdEnumerate(deployCmd, next) {
+	var cmd = deployCmd,
+		args = ['devices'], // TODO What timeout should we use here?
+		child = spawn(cmd, args),
+		out = '',
+		result;
+
+	child.stdout.on('data', function (data) {
+		out += data.toString();
+	});
+
+	child.stderr.on('data', function (data) {
+		out += data.toString();
+	});
+
+	child.on('close', function (code) {
+		if (code) {
+			var errmsg = out.trim().split(/\r\n|\n/).shift(),
+				ex = new Error(/^Error: /.test(errmsg) ? errmsg.substring(7) : __('Failed to enumerate devices for WP SDK 10.0 (code %s)', code));
+			next(ex, null);
+		} else {
+			// Try and parse device listing out of text!
+			var deviceListingRE = /^((\d{1,3}\.){3}\d{1,3})\s+([0-9A-F]{8}[-]?([0-9A-F]{4}[-]?){3}[0-9A-F]{12})\s+(.+?)$/igm;
+			var devices = [];
+			var match,
+				i = 0;
+			while ((match = deviceListingRE.exec(out)) !== null)
+			{
+				devices.push({name: match[5], udid: match[3], index: i, wpsdk: '10.0', ip: match[1]});
+				i++;
+			}
+
+			next(null, {
+				devices: devices,
+				emulators: []
+			});
+		}
+	});
+}
+
 /**
  * Detects all Windows Phone devices and emulators using our custom tooling (wptool.exe)
  *
@@ -46,7 +93,7 @@ exports.install = install;
  * @param {Function} [next(err, results)] - A function to call with the device information.
  */
 function wptoolEnumerate(wpsdk, options, next) {
-	// TODO Use WinAppDeployCmd to detect devices over USB/network for 10.0?
+	// TODO Can we modify our wptool to use APIs that WinAppDeployCmd uses to discover devices?
 	function run(wpsdk, next) {
 		var child = spawn(wptool, ['enumerate', '--wpsdk', wpsdk]),
 			out = '',
@@ -82,41 +129,59 @@ function wptoolEnumerate(wpsdk, options, next) {
 			return next(ex);
 		}
 
-		// TODO Handle when we don't have permissions to the folders in SDK and need to offload build to user HOME
-		fs.stat(wptool, function (err, stats) {
-			if (err) {
-				// file does not exist, build the tool and then run
-				if (err.code === 'ENOENT') {
-					return buildWpTool(options, function (err, path) {
-						if (err) {
-							return next(err);
-						}
-						run(wpsdk, next);
-					});
-				}
-				// some other error
-				return next(err);
-			}
-
-			// Compare modified time versus wptool.cs!
-			var wpToolCs = path.resolve(__dirname, '..', 'wptool', 'wptool.cs'),
-				sourceStats = fs.statSync(wpToolCs);
-			if (sourceStats.mtime > stats.mtime) {
-				// delete wptool and rebuild
-				return fs.unlink(wptool, function (err) {
+		// device discovery is slower, do it in parallel with emulator discovery/listing
+		async.parallel([
+			// discover windows 10 devices in network using WinAppDeployCmd
+			function (cb) {
+				winAppDeployCmdEnumerate(phoneResults.windowsphone[wpsdk].deployCmd, cb);
+			},
+			// Use our custom wptool binary to gather Windows 10 emulators
+			function (cb) {
+				// TODO Handle when we don't have permissions to the folders in SDK and need to offload build to user HOME
+				fs.stat(wptool, function (err, stats) {
 					if (err) {
-						return next(err);
-					}
-					buildWpTool(options, function (err, path) {
-						if (err) {
-							return next(err);
+						// file does not exist, build the tool and then run
+						if (err.code === 'ENOENT') {
+							return buildWpTool(options, function (err, path) {
+								if (err) {
+									return cb(err);
+								}
+								run(wpsdk, cb);
+							});
 						}
-						// then run
-						run(wpsdk, next);
-					});
+						// some other error
+						return cb(err);
+					}
+
+					// Compare modified time versus wptool.cs!
+					var wpToolCs = path.resolve(__dirname, '..', 'wptool', 'wptool.cs'),
+						sourceStats = fs.statSync(wpToolCs);
+					if (sourceStats.mtime > stats.mtime) {
+						// delete wptool and rebuild
+						return fs.unlink(wptool, function (err) {
+							if (err) {
+								return cb(err);
+							}
+							buildWpTool(options, function (err, path) {
+								if (err) {
+									return cb(err);
+								}
+								// then run
+								run(wpsdk, cb);
+							});
+						});
+					}
+					run(wpsdk, cb);
 				});
 			}
-			run(wpsdk, next);
+		], function (err, results) {
+			if (err) {
+				return next(err);
+			}
+			// Combine devices and emulators listings!
+			var combined = results[1];
+			combined.devices = results[0].devices;
+			return next(null, combined);
 		});
 	});
 }
@@ -166,7 +231,7 @@ function nativeEnumerate(wpsdk, options, next) {
 				next(ex, null);
 			} else {
 				// Parse the output! Hope this regex is OK!
-				var deviceListingRE = /^\s*(\d+)\s+([\w \.]+)/mg
+				var deviceListingRE = /^\s*(\d+)\s+([\w \.]+)/mg;
 				deviceListingRE.exec(out); // skip device
 				var emulators = [];
 				var match;
@@ -188,7 +253,7 @@ function nativeEnumerate(wpsdk, options, next) {
 
 				next(null, {
 					devices: [{name: 'Device', udid: 0, index: 0, wpsdk: null}],
-					emulators: emulators,
+					emulators: emulators
 				});
 			}
 		});

--- a/lib/wptool.js
+++ b/lib/wptool.js
@@ -37,6 +37,11 @@ var cache;
 exports.enumerate = enumerate;
 exports.connect = connect;
 exports.install = install;
+// expose some methods for unit testing
+exports.test = {
+	parseWinAppDeployCmdListing: parseWinAppDeployCmdListing,
+	parseAppDeployCmdListing: parseAppDeployCmdListing
+};
 
 
 /**
@@ -47,7 +52,7 @@ exports.install = install;
  */
 function winAppDeployCmdEnumerate(deployCmd, next) {
 	var cmd = deployCmd,
-		args = ['devices'], // TODO What timeout should we use here?
+		args = ['devices', '2'], // TODO What timeout should we use here? Using 2 seconds for now, since I think wptool takes that long anyways
 		child = spawn(cmd, args),
 		out = '',
 		result;
@@ -66,23 +71,32 @@ function winAppDeployCmdEnumerate(deployCmd, next) {
 				ex = new Error(/^Error: /.test(errmsg) ? errmsg.substring(7) : __('Failed to enumerate devices for WP SDK 10.0 (code %s)', code));
 			next(ex, null);
 		} else {
-			// Try and parse device listing out of text!
-			var deviceListingRE = /^((\d{1,3}\.){3}\d{1,3})\s+([0-9A-F]{8}[-]?([0-9A-F]{4}[-]?){3}[0-9A-F]{12})\s+(.+?)$/igm;
-			var devices = [];
-			var match,
-				i = 0;
-			while ((match = deviceListingRE.exec(out)) !== null)
-			{
-				devices.push({name: match[5], udid: match[3], index: i, wpsdk: '10.0', ip: match[1]});
-				i++;
-			}
-
+			var devices = parseWinAppDeployCmdListing(out);
 			next(null, {
 				devices: devices,
 				emulators: []
 			});
 		}
 	});
+}
+
+/**
+ * @param {String} [deployCmd] - Device listing output from WinAppDeployCmd.exe
+ * @return {Array[Object]} - Array of devices
+ **/
+function parseWinAppDeployCmdListing(out) {
+	var deviceListingRE = /^((\d{1,3}\.){3}\d{1,3})\s+([0-9A-F]{8}[-]?([0-9A-F]{4}[-]?){3}[0-9A-F]{12})\s+(.+?)$/igm;
+	var devices = [];
+	var match,
+		i = 0;
+	while ((match = deviceListingRE.exec(out)) !== null)
+	{
+		// TODO How can we know what SDK is on the phone? My win 8.1U1 phone shows up in listings when connected via USB
+		devices.push({name: match[5], udid: match[3], index: i, wpsdk: null, ip: match[1]});
+		i++;
+	}
+
+	return devices;
 }
 
 /**
@@ -93,7 +107,6 @@ function winAppDeployCmdEnumerate(deployCmd, next) {
  * @param {Function} [next(err, results)] - A function to call with the device information.
  */
 function wptoolEnumerate(wpsdk, options, next) {
-	// TODO Can we modify our wptool to use APIs that WinAppDeployCmd uses to discover devices?
 	function run(wpsdk, next) {
 		var child = spawn(wptool, ['enumerate', '--wpsdk', wpsdk]),
 			out = '',
@@ -187,6 +200,37 @@ function wptoolEnumerate(wpsdk, options, next) {
 }
 
 /**
+ * Parses the emulator listing from AppDeployCmd.exe
+ *
+ * @param {String} [out] - The raw string output from AppDeployCmd.exe
+ * @param {String} [wpsdk] - The windows phone sdk version ('8.0', '8.1', '10.0').
+ * @return {Array[Object]} - An array of the emulators detected
+ */
+function parseAppDeployCmdListing(out, wpsdk) {
+	// Parse the output! Hope this regex is OK!
+	var deviceListingRE = /^\s*(\d+)\s+([\w \.]+)/mg;
+	deviceListingRE.exec(out); // skip device
+	var emulators = [];
+	var match;
+	while ((match = deviceListingRE.exec(out)) !== null)
+	{
+		emulators.push({name: match[2], udid: wpsdk.replace('.', '-') + "-" + match[1], index: parseInt(match[1]), wpsdk: wpsdk});
+	}
+
+	// TIMOB-19576
+	// Windows 10 Mobile Emulators are detected by 8.1 sdk,
+	// which can be used for both 8.1 and 10 project.
+	if (wpsdk != '8.0') {
+		// limit 8.1 or 10.0 emulators to those SDKs only
+		emulators = emulators.filter(function (e) {
+			return new RegExp("Emulator\ " + wpsdk).test(e.name);
+		});
+		// FIXME change the udids back if they don't start at 1? (If we have 8.1 and 10, the 8.1 emulators udids start at 8-1-7)
+	}
+	return emulators;
+}
+
+/**
  * Detects all Windows Phone devices and emulators using the native tooling (AppDeployCmd.exe)
  *
  * @param {String} [wpsdk] - The windows phone sdk version ('8.0', '8.1', '10.0').
@@ -230,27 +274,7 @@ function nativeEnumerate(wpsdk, options, next) {
 					ex = new Error(/^Error: /.test(errmsg) ? errmsg.substring(7) : __('Failed to enumerate devices/emulators for WP SDK %s (code %s)', wpsdk, code));
 				next(ex, null);
 			} else {
-				// Parse the output! Hope this regex is OK!
-				var deviceListingRE = /^\s*(\d+)\s+([\w \.]+)/mg;
-				deviceListingRE.exec(out); // skip device
-				var emulators = [];
-				var match;
-				while ((match = deviceListingRE.exec(out)) !== null)
-				{
-					emulators.push({name: match[2], udid: wpsdk.replace('.', '-') + "-" + match[1], index: parseInt(match[1]), wpsdk: wpsdk});
-				}
-
-				// TIMOB-19576
-				// Windows 10 Mobile Emulators are detected by 8.1 sdk,
-				// which can be used for both 8.1 and 10 project.
-				if (wpsdk != '8.0') {
-					// limit 8.1 or 10.0 emulators to those SDKs only
-					emulators = emulators.filter(function (e) {
-						return new RegExp("Emulator\ " + wpsdk).test(e.name);
-					});
-					// FIXME change the udids back if they don't start at 1? (If we have 8.1 and 10, the 8.1 emulators udids start at 8-1-7)
-				}
-
+				var emulators = parseAppDeployCmdListing(out, wpsdk);
 				next(null, {
 					devices: [{name: 'Device', udid: 0, index: 0, wpsdk: null}],
 					emulators: emulators
@@ -716,7 +740,7 @@ function nativeInstall(deployCmd, device, appPath, options, callback) {
  * first launch the emulator and grab the IP address before installing.
  *
  * @param {String} [deployCmd] - Path to WinAppDeployCmd.exe
- * @param {Object} [device] - The windows phonedevice or emulator.
+ * @param {Object} [device] - The windows phone device or emulator.
  * @param {String} [appPath] - Path to the appx, xap or appxbundle to install.
  * @param {Object} [options] - An object containing various settings.
  * @param {Function} [callback(err, device)] - A function to call with the device information.
@@ -752,6 +776,8 @@ function wpToolInstall(deployCmd, device, appPath, options, callback) {
 		out += data.toString();
 	});
 
+	// TODO If the app install fails because it needs a pin, we should help guide the user. Prompt for pin, or spit out a message
+	// telling them how to install manually and pair once with pin?
 	child.on('close', function (code) {
 		clearTimeout(abortTimer);
 

--- a/test/test-wptool.js
+++ b/test/test-wptool.js
@@ -18,6 +18,103 @@ describe('wptool', function () {
 		should(windowslib.wptool).be.an.Object;
 	});
 
+	it('should parse Windows 10 WinAppDeployCmd.exe device listing output', function (done) {
+		this.timeout(1000);
+		this.slow(500);
+
+		var output = 'Windows App Deployment Tool\r\nVersion 10.0.0.0\r\nCopyright (c) Microsoft Corporation. All rights reserved.\r\n\r\nDiscovering devices...\r\nIP Address      GUID                                    Model/Name\r\n127.0.0.1       00000045-8aab-6667-0000-000000000000    Windows Phone 8\r\n10.120.68.150   00000015-b21e-0da9-0000-000000000000    Lumia 1520 (RM-940)\r\n10.120.70.172   00000000-0000-0000-0000-00155d619532    00155D619532\r\nDone.';
+		var devices = windowslib.wptool.test.parseWinAppDeployCmdListing(output);
+		should(devices).be.an.Array;
+		should(devices.length).equal(3); // 3 devices in listing
+
+
+		devices.forEach(function (d) {
+			should(d).be.an.Object;
+			should(d).have.ownProperty('name');
+			should(d).have.ownProperty('udid');
+			should(d).have.ownProperty('index');
+			should(d).have.ownProperty('wpsdk');
+			should(d).have.ownProperty('ip');
+
+			should(d.name).be.a.String;
+			should(d.index).be.an.Integer;
+			should(d.udid).be.a.String;
+			should(d.ip).be.a.String;
+		});
+
+		// Windows Phone 8
+		should(devices[0].name).equal('Windows Phone 8');
+		should(devices[0].index).equal(0);
+		should(devices[0].udid).equal('00000045-8aab-6667-0000-000000000000');
+		should(devices[0].ip).equal('127.0.0.1');
+
+		// Lumia 1520 (RM-940)
+		should(devices[1].name).equal('Lumia 1520 (RM-940)');
+		should(devices[1].index).equal(1);
+		should(devices[1].udid).equal('00000015-b21e-0da9-0000-000000000000');
+		should(devices[1].ip).equal('10.120.68.150');
+
+		// 00155D619532
+		should(devices[2].name).equal('00155D619532');
+		should(devices[2].index).equal(2);
+		should(devices[2].udid).equal('00000000-0000-0000-0000-00155d619532');
+		should(devices[2].ip).equal('10.120.70.172');
+
+		done();
+	});
+
+	it('should parse Windows 8.1 AppDeployCmd.exe emulator listing output', function (done) {
+		this.timeout(1000);
+		this.slow(500);
+
+		var	wpsdk = '8.1', // Get the 8.1 emulators from the output
+			output = '\r\n' +
+				'Device Index    Device Name\r\n' +
+				'------------    -------------------------------\r\n' +
+				' 0              Device\r\n' +
+				' 1              Mobile Emulator 10.0.10586.0 WVGA 4 inch 512MB\r\n' +
+				' 2              Mobile Emulator 10.0.10586.0 WVGA 4 inch 1GB\r\n' +
+				' 3              Mobile Emulator 10.0.10586.0 WXGA 4.5 inch 1GB\r\n' +
+				' 4              Mobile Emulator 10.0.10586.0 720p 5 inch 1GB\r\n' +
+				' 5              Mobile Emulator 10.0.10586.0 1080p 6 inch 2GB\r\n' +
+				' 6              Mobile Emulator 10.0.10586.0 QHD 5.2 inch 3GB\r\n' +
+				' 7              Emulator 8.1 U1 WVGA 4 inch 512MB\r\n' +
+				' 8              Emulator 8.1 U1 WVGA 4 inch\r\n' +
+				' 9              Emulator 8.1 U1 WXGA 4.5 inch\r\n' +
+				' 10             Emulator 8.1 U1 720P 4.7 inch\r\n' +
+				' 11             Emulator 8.1 U1 1080P 5.5 inch\r\n' +
+				' 12             Emulator 8.1 U1 1080P 6 inch\r\n' +
+				' 13             Emulator 8.1 U1 qHD 5 inch\r\n' +
+				' 14             Emulator 8.1 WVGA 4 inch 512MB\r\n' +
+				' 15             Emulator 8.1 WVGA 4 inch\r\n' +
+				' 16             Emulator 8.1 WXGA 4.5 inch\r\n' +
+				' 17             Emulator 8.1 720P 4.7 inch\r\n' +
+				' 18             Emulator 8.1 1080P 5.5 inch\r\n' +
+				' 19             Emulator 8.1 1080P 6 inch\r\n' +
+				'Done.';
+		var emulators = windowslib.wptool.test.parseAppDeployCmdListing(output, wpsdk);
+		should(emulators).be.an.Array;
+		should(emulators.length).equal(13); // 13 8.1 emulators in listing, we filter out the 10.0 emulators
+
+		// TODO Verify name and udid matches the listing above
+		emulators.forEach(function (e) {
+			should(e).be.an.Object;
+			should(e).have.ownProperty('name');
+			should(e).have.ownProperty('udid');
+			should(e).have.ownProperty('index');
+			should(e).have.ownProperty('wpsdk');
+
+			should(e.name).be.a.String;
+			should(e.name).not.equal('');
+
+			should(e.index).be.an.Integer;
+
+			should(e.wpsdk).equal(wpsdk);
+		});
+
+		done();
+	});
+
 	(process.platform === 'win32' ? it : it.skip)('should enumerate all Windows Phone devices and emulators', function (done) {
 		this.timeout(5000);
 		this.slow(4000);


### PR DESCRIPTION
https://jira.appcelerator.org/browse/TIMOB-20096

I don't have a windows 10 phone to test this with, so hopefully @infosia you can? I did connect my Windows 8.1U1 phone via USB and got it listed in the WinAppDeployCmd output, but couldn't test installing an app to it (since it's not a Win 10 mobile device!)

Basically we just run {{WinAppDeployCmd.exe devices 2}} to gather a list of devices and parse it using a regex, similar to how we parse the Windows 8.1 AppDeployCmd.exe output for emulators.

If a pin is required to pair to a device the first time, we just fail miserably (I assume). Likely we'd want to output at least a message asking the user to install the app once with their device pin and basically spit out the exact command line they should use (with <pin> placeholder arg). I just left a TODO because I don't even know if we need a pin on an actual device or not.