### PR TITLE
Parse Get-AppxPackage output into JSON

### DIFF
--- a/lib/winstore.js
+++ b/lib/winstore.js
@@ -4,7 +4,7 @@
  * @module winstore
  *
  * @copyright
- * Copyright (c) 2014 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2014-2016 by Appcelerator, Inc. All Rights Reserved.
  *
  * @license
  * Licensed under the terms of the Apache Public License.
@@ -29,6 +29,7 @@ exports.install = install;
 exports.launch = launch;
 exports.uninstall = uninstall;
 exports.detect = detect;
+exports.getAppxPackages = getAppxPackages;
 
 /**
  * Installs a Windows Store application.
@@ -106,6 +107,58 @@ function install(projectDir, options, callback) {
 }
 
 /**
+ * Calls Get-AppxPackage for the full listing of app packages and returns the results as a JSON object keyed by the app name.(appid)
+ *
+ * @param {Object} [options] - An object containing various settings.
+ * @param {String} [options.powershell='powershell'] - Path to the 'powershell' executable.
+ * @param {Function} [callback(err, packages)] - A function to call when we have an error or the full package listing as JSON
+ **/
+function getAppxPackages(options, callback) {
+	appc.subprocess.run(options.powershell || 'powershell', ['-command', 'Get-AppxPackage'], function (code, out, err) {
+		if (code) {
+			var ex = new Error(__('Could not query the list of installed Windows Store apps: %s', err || code));
+			return callback(ex);
+		}
+
+		var keyValueRegexp = /([a-z]+)\s+:\s(.*)/i,
+			packageName,
+			packages = {};
+		// FIXME This isn't smart about keys with empty values, or values that span multiple lines in the output!
+		out.split(/\r\n|\n/).forEach(function (line) {
+			var l = line.trim();
+			var m = l.match(keyValueRegexp);
+			if (m) {
+				if (m[1] == 'Name') {
+					packageName = m[2];
+					packages[packageName] = {};
+				}
+				// store key / value pair for package
+				packages[packageName][m[1]] = m[2];
+			}
+		});
+
+		callback(null, packages);
+	});
+}
+
+/**
+ * Returns the PackageFullName for an app given it's appid.
+ *
+ * @param {String} appId - The application id.
+ * @param {Object} [options] - An object containing various settings.
+ * @param {String} [options.powershell='powershell'] - Path to the 'powershell' executable.
+ * @param {Function} [callback(err, packageName)] - A function to call when we have an error or get the final value
+ **/
+function getPackageFullName(appId, options, callback) {
+	getAppxPackages(options, function (err, packages) {
+		if (err) {
+			return callback(err);
+		}
+		return callback(null, packages[appId].PackageFullName);
+	});
+}
+
+/**
  * Uninstalls a Windows Store application.
  *
  * @param {String} appId - The application id.
@@ -120,23 +173,11 @@ function install(projectDir, options, callback) {
  */
 function uninstall(appId, options, callback) {
 	return magik(options, callback, function (emitter, options, callback) {
-		appc.subprocess.run(options.powershell || 'powershell', ['-command', 'Get-AppxPackage'], function (code, out, err) {
-			if (code) {
-				var ex = new Error(__('Could not query the list of installed Windows Store apps: %s', err || code));
-				emitter.emit('error', ex);
-				return callback(ex);
+		getPackageFullName(appId, options, function(err, packageName) {
+			if (err) {
+				emitter.emit('error', err);
+				return callback(err);
 			}
-
-			var packageNameRegExp = new RegExp('PackageFullName[\\s]*:[\\s]*(' + appId + '.*)'),
-				packageName;
-
-			out.split(/\r\n|\n/).some(function (line) {
-				var m = line.trim().match(packageNameRegExp);
-				if (m) {
-					packageName = m[1];
-					return true;
-				}
-			});
 
 			if (packageName) {
 				appc.subprocess.run(options.powershell || 'powershell', ['-command', 'Remove-AppxPackage', packageName], function (code, out, err) {
@@ -319,7 +360,7 @@ function detect(options, callback) {
 							if (parts.length == 3) {
 								if (parts[0] == 'InstallationFolder') {
 									results.windows[ver].path = parts[2];
-									
+
 									function addIfExists(key, exe) {
 										for (var i = 0; i < architectures.length; i++) {
 											var arch = architectures[i],

--- a/test/test-winstore.js
+++ b/test/test-winstore.js
@@ -28,6 +28,8 @@ describe('winstore', function () {
 		windowslib.winstore.launch(appid, opts, done);
 	});
 
+	// TODO Add tests for getAppxPackages, launch, install, uninstall
+
 	(process.platform === 'win32' ? it : it.skip)('detect should find Windows Store SDK installations', function (done) {
 		this.timeout(5000);
 		this.slow(2000);


### PR DESCRIPTION
These are changes to support the ability to get metadata about Windows runtime apps, which are required to exempt apps from the loopback ip network block. This is a change required to fix https://jira.appcelerator.org/browse/TIMOB-20370

Basically we call `powershell Get-AppxPackage` and turn the results into JSON where the keys are the app Name value and the set of key/value pairs are stored on the object. That way we can look up an app by it's "Name" (which should match our appId!) and then ask for details about the app from windows knowledge (like `PackageFamilyName`, which we need to exempt the app from network isolation for loopback IP). We happened to do something close where we just looked for one key/value pair to find the `PackageFullName` for when we uninstalled previously installed copies/versions of the app.

See https://msdn.microsoft.com/en-us/library/windows/apps/hh780593.aspx for details on why we need to do this funky loopback ip network isolation fix...