### PR TITLE
Move loopbackExempt into windowslib

### DIFF
--- a/bin/wp_get_appx_metadata.ps1
+++ b/bin/wp_get_appx_metadata.ps1
@@ -29,6 +29,5 @@ $manifest.Xml = [xml](get-content $manifest.Path)
 Remove-Item $zipFilePath
 Remove-Item $manifest.Path
 
-$var=@($manifest.Xml.Package.Identity.Name,$manifest.Xml.Package.PhoneIdentity.PhoneProductId)[![String]::IsNullOrEm
-pty($manifest.Xml.Package.PhoneIdentity.PhoneProductId)]
+$var=@($manifest.Xml.Package.Identity.Name,$manifest.Xml.Package.PhoneIdentity.PhoneProductId)[![String]::IsNullOrEmpty($manifest.Xml.Package.PhoneIdentity.PhoneProductId)]
 $var

--- a/lib/process.js
+++ b/lib/process.js
@@ -4,7 +4,7 @@
  * @module process
  *
  * @copyright
- * Copyright (c) 2014 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2014-2016 by Appcelerator, Inc. All Rights Reserved.
  *
  * @license
  * Licensed under the terms of the Apache Public License.
@@ -17,9 +17,11 @@ const
 	fs = require('fs'),
 	magik = require('./utilities').magik,
 	path = require('path'),
-	__ = appc.i18n(__dirname).__;
+	__ = appc.i18n(__dirname).__,
+	LIST_RE = /^([^:]+):\s+(.*)$/;
 
 exports.list = list;
+exports.find = find;
 
 /**
  * Returns a list of running processes.
@@ -44,22 +46,8 @@ function list(options, callback) {
 				return callback(ex);
 			}
 
-			var re = /^([^:]+):\s+(.*)$/;
-
 			out.trim().split(/\r\n\r\n|\n\n/).forEach(function (chunk) {
-				var obj = {};
-
-				chunk.split(/\r\n|\n/).forEach(function (line) {
-					var m = line.match(re);
-					if (!m) return;
-
-					switch (m[1].toLowerCase()) {
-						case 'image name':    obj.name  = m[2];    break;
-						case 'pid':           obj.pid   = ~~m[2];  break;
-						case 'window title':  obj.title = m[2];    break;
-					}
-				});
-
+				var obj = parseProcessOutput(chunk);
 				processes.push(obj);
 			});
 
@@ -68,3 +56,53 @@ function list(options, callback) {
 		});
 	});
 };
+
+/**
+ * Returns a single running process's info. If it's not running, we return null.
+ *
+ * @param {String} pid - The process if od the process we're looking for.
+ * @param {Object} [options] - An object containing various settings.
+ * @param {String} [options.tasklist] - The path to the 'tasklist' executable.
+ * @param {Function} [callback(err, results)] - A function to call with the process.
+ *
+ * @emits module:process#process
+ * @emits module:process#error
+ *
+ * @returns {EventEmitter}
+ */
+function find(pid, options, callback) {
+	return magik(options, callback, function (emitter, options, callback) {
+		appc.subprocess.run(options.tasklist || 'tasklist', ['/FI', 'PID eq ' + pid, '/FO', 'LIST', '/V'], function (code, out, err) {
+			var processes = [];
+
+			if (code) {
+				var ex = new Error(__('Failed to run "%s"', 'tasklist'));
+				emitter.emit('error', ex);
+				return callback(ex);
+			}
+
+			if (out.indexOf('PID:') == -1) {
+				// not running
+				return callback();
+			}
+			var obj = parseProcessOutput(out.trim());
+			emitter.emit('process', obj);
+			callback(null, obj);
+		});
+	});
+};
+
+function parseProcessOutput(chunk) {
+	var obj = {};
+	chunk.split(/\r\n|\n/).forEach(function (line) {
+		var m = line.match(LIST_RE);
+		if (!m) return;
+
+		switch (m[1].toLowerCase()) {
+			case 'image name':    obj.name  = m[2];    break;
+			case 'pid':           obj.pid   = ~~m[2];  break;
+			case 'window title':  obj.title = m[2];    break;
+		}
+	});
+	return obj;
+}

--- a/lib/winstore.js
+++ b/lib/winstore.js
@@ -16,6 +16,7 @@ const
 	async = require('async'),
 	fs = require('fs'),
 	magik = require('./utilities').magik,
+	checkOutdated = require('./utilities').checkOutdated,
 	path = require('path'),
 	visualstudio = require('./visualstudio'),
 	__ = appc.i18n(__dirname).__;
@@ -30,6 +31,7 @@ exports.launch = launch;
 exports.uninstall = uninstall;
 exports.detect = detect;
 exports.getAppxPackages = getAppxPackages;
+exports.loopbackExempt = loopbackExempt;
 
 /**
  * Installs a Windows Store application.
@@ -142,6 +144,35 @@ function getAppxPackages(options, callback) {
 }
 
 /**
+ * Makes a given app (identified by appid) exempt from network isolation for the
+ * loopback IP. Useful for exempting store apps so we can do log relaying to CLI.
+ *
+ * @param {String} appId - The application id.
+ * @param {Object} [options] - An object containing various settings.
+ * @param {String} [options.powershell='powershell'] - Path to the 'powershell' executable.
+ * @param {Function} [callback(err)] - A function to call when we have an error or completed exempting the app from loopback ip network isolation
+ **/
+function loopbackExempt(appId, options, callback) {
+	getAppxPackages(options, function (err, packages) {
+		if (err) {
+			return callback(err);
+		}
+
+		if (!packages[appId]) {
+			var ex = new Error(__('Unable to find an installed app with id: %s', appId));
+			return callback(ex);
+		}
+
+		appc.subprocess.run('CheckNetIsolation.exe', ['LoopbackExempt', '-a', '-n=' + packages[appId].PackageFamilyName], function (code, out, err) {
+			if (!code) {
+				return callback();
+			}
+			return callback(err);
+		});
+	});
+}
+
+/**
  * Returns the PackageFullName for an app given it's appid.
  *
  * @param {String} appId - The application id.
@@ -153,6 +184,11 @@ function getPackageFullName(appId, options, callback) {
 	getAppxPackages(options, function (err, packages) {
 		if (err) {
 			return callback(err);
+		}
+
+		if (!packages[appId]) {
+			var ex = new Error(__('Unable to find an installed app with id: %s', appId));
+			return callback(ex);
 		}
 		return callback(null, packages[appId].PackageFullName);
 	});
@@ -205,10 +241,10 @@ function uninstall(appId, options, callback) {
  * @param {Object} [options] - An object containing various settings.
  * @param {String} [options.powershell='powershell'] - Path to the 'powershell' executable.
  * @param {String} [options.version] - The specific version of the app to launch. If empty, picks the largest version.
- * @param {Function} [callback(err)] - A function to call after uninstalling the Windows Store app.
+ * @param {Function} [callback(err, pid)] - A function to call after launching the Windows Store app. pid is output from wstool which should be pid of process launched
  *
  * @emits module:winstore#error
- * @emits module:winstore#launched
+ * @emits module:winstore#installed
  *
  * @returns {EventEmitter}
  */
@@ -235,39 +271,62 @@ function launch(appId, options, callback) {
 					emitter.emit('error', ex);
 					callback(ex);
 				} else {
-					emitter.emit('installed');
-					callback();
+					emitter.emit('installed', out);
+					callback(null, out);
 				}
 			});
 		}
 
-		if (fs.existsSync(wstool)) {
-			runTool();
-		} else {
-			visualstudio.build(appc.util.mix({
-				buildConfiguration: 'Release',
-				project: path.resolve(__dirname, '..', 'wstool', 'wstool.csproj')
-			}, options), function (err, result) {
-				if (err) {
-					emitter.emit('error', err);
-					return callback(err);
-				}
+		var wsToolCs = path.resolve(__dirname, '..', 'wstool', 'wstool.cs');
+		checkOutdated(wsToolCs, wstool, function(err, outdated) {
+			if (err) {
+				emitter.emit('error', err);
+				return callback(err);
+			}
 
-				var src = path.resolve(__dirname, '..', 'wstool', 'bin', 'Release', 'wstool.exe');
-				if (!fs.existsSync(src)) {
-					var ex = new Error(__('Failed to build the wstool executable.') + (result ? '\n' + result.out : ''));
-					emitter.emit('error', ex);
-					return callback(ex);
-				}
+			if (outdated) {
+				return buildWsTool(options, function (err, path) {
+					if (err) {
+						emitter.emit('error', err);
+						return callback(err);
+					}
+					runTool();
+				});
+			}
 
-				// sanity check that the wstool.exe wasn't copied by another async task in windowslib
-				if (!fs.existsSync(wstool)) {
-					fs.writeFileSync(wstool, fs.readFileSync(src));
-				}
+			return runTool();
+		});
+	});
+}
 
-				runTool();
-			});
+/**
+ * Builds our custom wstool.exe from source
+ *
+ * @param {Object} [options] - An object containing various settings.
+ * @param {String} [options.powershell='powershell'] - Path to the 'powershell' executable.
+ * @param {Function} [callback(err, path)] - A function to call after building wstool.exe
+ */
+function buildWsTool(options, callback) {
+	visualstudio.build(appc.util.mix({
+		buildConfiguration: 'Release',
+		project: path.resolve(__dirname, '..', 'wstool', 'wstool.csproj')
+	}, options), function (err, result) {
+		if (err) {
+			return callback(err);
 		}
+
+		var src = path.resolve(__dirname, '..', 'wstool', 'bin', 'Release', 'wstool.exe');
+		if (!fs.existsSync(src)) {
+			var ex = new Error(__('Failed to build the wstool executable.') + (result ? '\n' + result.out : ''));
+			return callback(ex);
+		}
+
+		// sanity check that the wstool.exe wasn't copied by another async task in windowslib
+		if (!fs.existsSync(wstool)) {
+			fs.writeFileSync(wstool, fs.readFileSync(src));
+		}
+
+		callback(null, wstool);
 	});
 }
 

--- a/lib/winstore.js
+++ b/lib/winstore.js
@@ -124,18 +124,32 @@ function getAppxPackages(options, callback) {
 
 		var keyValueRegexp = /([a-z]+)\s+:\s(.*)/i,
 			packageName,
-			packages = {};
-		// FIXME This isn't smart about keys with empty values, or values that span multiple lines in the output!
+			packages = {},
+			key = '';
+		// FIXME This isn't smart about keys with empty values
 		out.split(/\r\n|\n/).forEach(function (line) {
-			var l = line.trim();
-			var m = l.match(keyValueRegexp);
-			if (m) {
-				if (m[1] == 'Name') {
-					packageName = m[2];
+			var trimmed = line.trim(),
+				m = trimmed.match(keyValueRegexp),
+				value;
+			if (m) { // key/value pair
+				key = m[1];
+				value = m[2];
+				if (key == 'Name') {
+					packageName = value;
 					packages[packageName] = {};
 				}
-				// store key / value pair for package
-				packages[packageName][m[1]] = m[2];
+				// store key / value pair for package, "cast" 'False' to false boolean, 'True' to true boolean
+				if (value == 'False') {
+					value = false;
+				} else if (value == 'True') {
+					value = true;
+				}
+				packages[packageName][key] = value;
+			} else { // no match, so either empty line or continuation of multiline value
+				if (trimmed.length > 0) {
+					// append value to last key!
+					packages[packageName][key] += trimmed;
+				}
 			}
 		});
 

--- a/lib/winstore.js
+++ b/lib/winstore.js
@@ -19,7 +19,8 @@ const
 	checkOutdated = require('./utilities').checkOutdated,
 	path = require('path'),
 	visualstudio = require('./visualstudio'),
-	__ = appc.i18n(__dirname).__;
+	__ = appc.i18n(__dirname).__,
+	wstool = path.resolve(__dirname, '..', 'bin', 'wstool.exe');
 
 var architectures = [ 'arm', 'x86', 'x64' ];
 
@@ -200,11 +201,7 @@ function getPackageFullName(appId, options, callback) {
 			return callback(err);
 		}
 
-		if (!packages[appId]) {
-			var ex = new Error(__('Unable to find an installed app with id: %s', appId));
-			return callback(ex);
-		}
-		return callback(null, packages[appId].PackageFullName);
+		return callback(null, packages[appId] && packages[appId].PackageFullName);
 	});
 }
 
@@ -264,8 +261,6 @@ function uninstall(appId, options, callback) {
  */
 function launch(appId, options, callback) {
 	return magik(options, callback, function (emitter, options, callback) {
-		var wstool = path.resolve(__dirname, '..', 'bin', 'wstool.exe');
-
 		function runTool() {
 			var args = ['launch', '--appid', appId];
 
@@ -285,8 +280,8 @@ function launch(appId, options, callback) {
 					emitter.emit('error', ex);
 					callback(ex);
 				} else {
-					emitter.emit('installed', out);
-					callback(null, out);
+					emitter.emit('installed', out.trim());
+					callback(null, out.trim());
 				}
 			});
 		}

--- a/lib/wptool.js
+++ b/lib/wptool.js
@@ -19,6 +19,7 @@ const
 	DOMParser = require('xmldom').DOMParser,
 	fs = require('fs'),
 	magik = require('./utilities').magik,
+	checkOutdated = require('./utilities').checkOutdated,
 	path = require('path'),
 	spawn = require('child_process').spawn,
 	visualstudio = require('./visualstudio'),
@@ -151,39 +152,20 @@ function wptoolEnumerate(wpsdk, options, next) {
 			// Use our custom wptool binary to gather Windows 10 emulators
 			function (cb) {
 				// TODO Handle when we don't have permissions to the folders in SDK and need to offload build to user HOME
-				fs.stat(wptool, function (err, stats) {
+				var wpToolCs = path.resolve(__dirname, '..', 'wptool', 'wptool.cs');
+				checkOutdated(wpToolCs, wptool, function (err, outdated) {
 					if (err) {
-						// file does not exist, build the tool and then run
-						if (err.code === 'ENOENT') {
-							return buildWpTool(options, function (err, path) {
-								if (err) {
-									return cb(err);
-								}
-								run(wpsdk, cb);
-							});
-						}
-						// some other error
 						return cb(err);
 					}
-
-					// Compare modified time versus wptool.cs!
-					var wpToolCs = path.resolve(__dirname, '..', 'wptool', 'wptool.cs'),
-						sourceStats = fs.statSync(wpToolCs);
-					if (sourceStats.mtime > stats.mtime) {
-						// delete wptool and rebuild
-						return fs.unlink(wptool, function (err) {
+					if (outdated) {
+						return buildWpTool(options, function (err, path) {
 							if (err) {
 								return cb(err);
 							}
-							buildWpTool(options, function (err, path) {
-								if (err) {
-									return cb(err);
-								}
-								// then run
-								run(wpsdk, cb);
-							});
+							run(wpsdk, cb);
 						});
 					}
+
 					run(wpsdk, cb);
 				});
 			}
@@ -924,8 +906,8 @@ function getProductGUID(appxFile, options, callback) {
 			appxFile
 		], function (code, out, err) {
 			if (code) {
-				var err = new Error(__('Failed to detect product id of appx'));
-				return callback(err);
+				var ex = new Error(__('Failed to detect product id of appx: %s', out));
+				return callback(ex);
 			}
 
 			callback(null, out.trim());

--- a/test/test-device.js
+++ b/test/test-device.js
@@ -34,7 +34,7 @@ describe('device', function () {
 			should(results.devices).be.an.Array;
 			results.devices.forEach(function (dev) {
 				should(dev).be.an.Object;
-				should(dev).have.keys('name', 'udid', 'index', 'wpsdk');
+				should(dev).have.properties('name', 'udid', 'index', 'wpsdk'); // may also have 'ip'
 
 				should(dev.name).be.a.String;
 				should(dev.name).not.equal('');

--- a/test/test-emulator.js
+++ b/test/test-emulator.js
@@ -2,7 +2,7 @@
  * Tests windowslib's emulator module.
  *
  * @copyright
- * Copyright (c) 2014-2015 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2014-2016 by Appcelerator, Inc. All Rights Reserved.
  *
  * @license
  * Licensed under the terms of the Apache Public License.
@@ -139,7 +139,7 @@ describe('emulator', function () {
 		});
 
 		// Shut down the emulator
-		before(function (done) {
+		after(function (done) {
 			if (!emu) {
 				return done();
 			}
@@ -147,8 +147,10 @@ describe('emulator', function () {
 			windowslib.emulator.stop({
 				name: emu.name
 			}, function () {
-				done();
+				// do nothing
 			});
+
+			done();
 		});
 
 		it('launch and shutdown emulator', function (done) {

--- a/test/test-process.js
+++ b/test/test-process.js
@@ -2,7 +2,7 @@
  * Tests windowslib's process module.
  *
  * @copyright
- * Copyright (c) 2014 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2014-2016 by Appcelerator, Inc. All Rights Reserved.
  *
  * @license
  * Licensed under the terms of the Apache Public License.
@@ -30,6 +30,52 @@ describe('process', function () {
 			results.forEach(function (proc) {
 				should(proc).have.keys('name', 'pid', 'title');
 			});
+
+			done();
+		});
+	});
+
+	(process.platform === 'win32' ? it : it.skip)('find process by pid returns null for process not running', function (done) {
+		this.timeout(500);
+		this.slow(200);
+		// FIXME let's hope there's no process using this pid?
+		windowslib.process.find('12345', function (err, p) {
+			if (err) {
+				return done(err);
+			}
+
+			should(p).be.null;
+
+			done();
+		});
+	});
+
+	(process.platform === 'win32' ? it : it.skip)('find process by pid returns error if pid is not integer', function (done) {
+		this.timeout(500);
+		this.slow(200);
+		// use bad pid value
+		windowslib.process.find('abc', function (err, p) {
+			if (!err) {
+				return done('tasklist should have failed due to invalid pid type');
+			}
+
+			should(p).be.null;
+
+			done();
+		});
+	});
+
+	(process.platform === 'win32' ? it : it.skip)('find process by pid', function (done) {
+		this.timeout(500);
+		this.slow(200);
+		// find our own process
+		windowslib.process.find(process.pid, function (err, p) {
+			if (err) {
+				return done(err);
+			}
+
+			should(p).be.an.Object;
+			should(p).have.keys('name', 'pid', 'title');
 
 			done();
 		});

--- a/test/test-winstore.js
+++ b/test/test-winstore.js
@@ -28,7 +28,41 @@ describe('winstore', function () {
 		windowslib.winstore.launch(appid, opts, done);
 	});
 
-	// TODO Add tests for getAppxPackages, launch, install, uninstall
+	// TODO Add tests for launch, install, uninstall, loopbackExempt
+
+	(process.platform === 'win32' ? it : it.skip)('getAppxPackages should have preset Windows packages', function (done) {
+		this.timeout(2000);
+		this.slow(1250);
+
+		windowslib.winstore.getAppxPackages({}, function (err, packages) {
+			if (err) {
+				return done(err);
+			}
+
+			should(packages).be.an.Object;
+			// Assume user didn't somehow remove Edge browser and alarms apps
+			should(packages).have.properties('Microsoft.MicrosoftEdge', 'Microsoft.WindowsAlarms');
+
+			// all apps should have same base set of keys
+			Object.keys(packages).forEach(function (appid) {
+				should(packages[appid]).have.properties('Name',
+					'Publisher', 'Architecture', 'Version',
+					'PackageFullName', 'InstallLocation', 'IsFramework',
+					'PackageFamilyName', 'PublisherId', 'IsResourcePackage',
+					'IsBundle', 'IsDevelopmentMode');
+			});
+
+			// sanity check some values for Edge Browser app
+			should(packages['Microsoft.MicrosoftEdge'].Publisher).equal('CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US');
+			should(packages['Microsoft.MicrosoftEdge'].Name).equal('Microsoft.MicrosoftEdge');
+
+			// sanity check some values for Alarms app
+			should(packages['Microsoft.WindowsAlarms'].Publisher).equal('CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US');
+			should(packages['Microsoft.WindowsAlarms'].Name).equal('Microsoft.WindowsAlarms');
+
+			done();
+		});
+	});
 
 	(process.platform === 'win32' ? it : it.skip)('detect should find Windows Store SDK installations', function (done) {
 		this.timeout(5000);

--- a/test/test-winstore.js
+++ b/test/test-winstore.js
@@ -45,11 +45,23 @@ describe('winstore', function () {
 
 			// all apps should have same base set of keys
 			Object.keys(packages).forEach(function (appid) {
-				should(packages[appid]).have.properties('Name',
-					'Publisher', 'Architecture', 'Version',
-					'PackageFullName', 'InstallLocation', 'IsFramework',
+				should(packages[appid]).have.properties('Name', 'Publisher',
+					'Architecture', 'Version', 'PackageFullName', 'IsFramework',
 					'PackageFamilyName', 'PublisherId', 'IsResourcePackage',
 					'IsBundle', 'IsDevelopmentMode');
+				// may also have Installocation, ResourceId, Dependencies
+				// check types of values are what we expect
+				should(packages[appid].Name).be.a.String;
+				should(packages[appid].Publisher).be.a.String;
+				should(packages[appid].Architecture).be.a.String;
+				should(packages[appid].Version).be.a.String;
+				should(packages[appid].PackageFullName).be.a.String;
+				should(packages[appid].IsFramework).be.a.Boolean;
+				should(packages[appid].PackageFamilyName).be.a.String;
+				should(packages[appid].PublisherId).be.a.String;
+				should(packages[appid].IsResourcePackage).be.a.Boolean;
+				should(packages[appid].IsBundle).be.a.Boolean;
+				should(packages[appid].IsDevelopmentMode).be.a.Boolean;
 			});
 
 			// sanity check some values for Edge Browser app
@@ -59,6 +71,9 @@ describe('winstore', function () {
 			// sanity check some values for Alarms app
 			should(packages['Microsoft.WindowsAlarms'].Publisher).equal('CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US');
 			should(packages['Microsoft.WindowsAlarms'].Name).equal('Microsoft.WindowsAlarms');
+
+			// check multiline value
+			should(packages['Microsoft.Windows.Photos'].Dependencies).equal('{Microsoft.VCLibs.140.00_14.0.22929.0_x64__8wekyb3d8bbwe,Microsoft.NET.Native.Runtime.1.1_1.1.23406.0_x64__8wekyb3d8bbwe,Microsoft.Windows.Photos_16.201.11370.0_neutral_split.scale-100_8wekyb3d8bbwe,Microsoft.Windows.Photos_16.201.11370.0_neutral_split.scale-150_8wekyb3d8bbwe}');
 
 			done();
 		});

--- a/wstool/wstool.cs
+++ b/wstool/wstool.cs
@@ -55,7 +55,7 @@ namespace wstool
 			if (version != null) {
 				foreach (var appKeyName in appListKey.GetSubKeyNames()) {
 					if (appKeyName.IndexOf(appid + "_" + version + "_") == 0) {
-						// Save the name, in case sub key doesn't exist 
+						// Save the name, in case sub key doesn't exist
 						windowsAppName = appKeyName;
 						var appKey = appListKey.OpenSubKey(appKeyName);
 						var appClassKey = appKey.OpenSubKey("ActivatableClassId\\App");
@@ -79,7 +79,7 @@ namespace wstool
 						if (q != -1) {
 							string thisVersion = appKeyName.Substring(p + 1, q);
 							if (lastVersion == null || String.Compare(thisVersion, lastVersion, true) > 0) {
-								// Save the name, in case sub key doesn't exist 
+								// Save the name, in case sub key doesn't exist
 								windowsAppName = appKeyName;
 								var appKey = appListKey.OpenSubKey(appKeyName);
 								var appClassKey = appKey.OpenSubKey("ActivatableClassId\\App");
@@ -117,7 +117,7 @@ namespace wstool
 				if (windowsAppId == null) {
 					windowsAppId = "App";
 				}
-				
+
 				// then we conbine it with the Windows Store application id...wish it generates valid one
 				appUserModelId = String.Format("{0}!{1}", familyName, windowsAppId);
 			}
@@ -131,6 +131,7 @@ namespace wstool
 				var aam = new ApplicationActivationManager();
 				UInt32 id;
 				aam.ActivateApplication(appUserModelId, null, ActivateOptions.None, out id);
+				Console.WriteLine(id);
 			} catch (System.Runtime.InteropServices.COMException) {
 				Console.WriteLine("Could not find version " + version + " of application " + appid + " in the registry. Is the application installed?");
 				return 1;


### PR DESCRIPTION
- Make wstool return pid after launching app.
- Move common code to utilities for checking if wptool/wstool need to be rebuilt.
- Add method for loopback exempting a Windows Store app by id/Name.
- Add a unit test for winstore.getAppxPackages()
- Fix broken wp_get_appx_metadata.ps1 file from newline mid-line