### PR TITLE
Improve log output from certutil

### DIFF
--- a/lib/certs.js
+++ b/lib/certs.js
@@ -139,7 +139,11 @@ function thumbprint(certificateFile, password, callback) {
 			callback(new Error('No certificate was found at the path: "' + certificateFile + '"'));
 		}
 		else {
-			callback(null, out.split('Cert Hash(sha1): ')[1].split('\r')[0].split(' ').join('').toUpperCase());
+			try {
+				callback(null, out.split('Cert Hash(sha1): ')[1].split('\r')[0].split(' ').join('').toUpperCase());
+			} catch (E) {
+				callback(new Error('Unexpected output: ' + E.toString() + '\n' + out));
+			}
 		}
 	});
 }


### PR DESCRIPTION
Improve log output when `certutil` fails. It includes actual output as well as JavaScript error.