### PR TITLE
[TIMOB-20566] Add support for Windows 10 devices

### DIFF
--- a/lib/wptool.js
+++ b/lib/wptool.js
@@ -768,7 +768,19 @@ function wpToolInstall(deployCmd, device, appPath, options, callback) {
 				ex = new Error(/^Error: /.test(errmsg) ? errmsg.substring(7) : __('Failed to install app (code %s): %s', code, out));
 			callback(ex);
 		} else {
-			callback(null, device);
+			var errmsg = /failed\. (\w*)\r?\n(.*)/.exec(out);
+			if (errmsg) {
+				var err = errmsg[1],
+					msg = errmsg[2];
+
+				if (err == '0x80073CF9') {
+					callback(new Error('A debug application is already installed, please remove existing debug application'));
+				} else {
+					callback(new Error(__('Failed to install app (code %s): %s', err, msg)));
+				}
+			} else {
+				callback(null, device);
+			}
 		}
 	});
 	if (options.timeout) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "windowslib",
-	"version": "0.4.3",
+	"version": "0.4.4",
 	"description": "Windows Phone Utility Library",
 	"keywords": [
 		"appcelerator",

--- a/wptool/wptool.cs
+++ b/wptool/wptool.cs
@@ -163,6 +163,18 @@ namespace wptool
 					return showHelp(String.Format("Invalid device UDID '{0:D}'", udid));
 				}
 
+				// ConnectableDevice throws an error when connecting to a physical Windows 10 device
+				// physical Windows 10 devices can be connected to using 127.0.0.1
+				if (connectableDevice.Version.Major == 10 && !connectableDevice.IsEmulator())
+				{
+					Console.WriteLine("{");
+					Console.WriteLine("\t\"success\": true,");
+					Console.WriteLine("\t\"ip\": \"127.0.0.1\",");
+					Console.WriteLine("\t\"osVersion\": \"" + connectableDevice.Version.ToString() + "\"");
+					Console.WriteLine("}");
+					return 0;
+				}
+
 				try {
 					IDevice device = connectableDevice.Connect();
 


### PR DESCRIPTION
- Add support for Windows 10 devices into ```wptool.cs```
- Add additional error reporting into ```wptool.js```

NOTE: Currently, it seems physical Windows 10 devices cannot be used with ```Microsoft.SmartDevice.MultiTargeting.Connectivity```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-20566)