### PR TITLE
[TIMOB-23181] Install app for Windows 10 Mobile fails on second install

### DIFF
--- a/lib/wptool.js
+++ b/lib/wptool.js
@@ -740,7 +740,7 @@ function wpToolInstall(deployCmd, device, appPath, options, callback) {
 	}
 
 	var args = [
-			'install',
+			options.forceUnInstall ? 'uninstall' : 'install',
 			'-file',
 			appPath,
 			'-ip',
@@ -775,11 +775,21 @@ function wpToolInstall(deployCmd, device, appPath, options, callback) {
 
 				if (err == '0x80073CF9') {
 					callback(new Error('A debug application is already installed, please remove existing debug application'));
+				} else if (err == '0x80073CFB') {
+					// Provided package has the same identity as an already-installed package. Proceed uninstalling.
+					options.forceUnInstall = true;
+					wpToolInstall(deployCmd, device, appPath, options, callback);
 				} else {
 					callback(new Error(__('Failed to install app (code %s): %s', err, msg)));
 				}
 			} else {
-				callback(null, device);
+				// Provided package is uninstalled...proceed re-installing.
+				if (options.forceUnInstall) {
+					options.forceUnInstall = false;
+					wpToolInstall(deployCmd, device, appPath, options, callback);
+				} else {
+					callback(null, device);
+				}
 			}
 		}
 	});


### PR DESCRIPTION
Fix for [TIMOB-23181](https://jira.appcelerator.org/browse/TIMOB-23181)

Fix `[ERROR] Failed to install app (code 0x80073CFB): Deployment of package xxx was blocked because the provided package has the same identity as an already-installed package but the contents are different. Increment the version number of the package to be installed, or remove the old package for every user on the system before installing this package.`. This fix basically tries to uninstall-then-install app when it has `0x80073CFB` error. This only happens on Windows 10 Mobile.

