### PR TITLE
[TIMOB-20571] Combine device listings

### DIFF
--- a/lib/wptool.js
+++ b/lib/wptool.js
@@ -175,7 +175,7 @@ function wptoolEnumerate(wpsdk, options, next) {
 			}
 			// Combine devices and emulators listings!
 			var combined = results[1];
-			combined.devices = results[0].devices;
+			combined.devices = results[0].devices.concat(combined.devices);
 			return next(null, combined);
 		});
 	});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "windowslib",
-	"version": "0.4.7",
+	"version": "0.4.8",
 	"description": "Windows Phone Utility Library",
 	"keywords": [
 		"appcelerator",


### PR DESCRIPTION
- Prevent device listings from ``wptool`` being overwritten by listings from ``winAppDeploy``

##### NOTE: This is required for https://github.com/appcelerator/titanium_mobile_windows/pull/620

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-20571)