### PR TITLE
[TIMOB-23253] Windows: Build errors when building to device and selecting second option in device prompt

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ function detect(options, callback) {
 			issues: []
 		};
 
-		async.each([env, visualstudio, windowsphone, assemblies, device, winstore, emulator], function (lib, next) {
+		async.each([env, visualstudio, windowsphone, assemblies, winstore, wptool], function (lib, next) {
 			lib.detect(options, function (err, result) {
 				err || mix(result, results);
 				next(err);

--- a/lib/device.js
+++ b/lib/device.js
@@ -123,49 +123,37 @@ function install(udid, appPath, options, callback) {
 			return callback(ex);
 		}
 
-		// detect devices
-		wptool.enumerate(options, function (err, devInfo) {
+		// detect devices, use cached listing!
+		detect(options, function (err, devInfo) {
 			if (err) {
 				emitter.emit('error', err);
 				return callback(err);
 			}
 
 			var devHandle;
+			var devices = devInfo.devices;
 
 			if (udid) {
 				// validate the udid
-				Object.keys(devInfo).filter(function (wpsdk) {
-					return !options.wpsdk || wpsdk === options.wpsdk;
-				}).some(function (wpsdk) {
-					return devInfo[wpsdk].devices.some(function (dev) {
-						if (dev.udid === udid) {
-							devHandle = appc.util.mix({}, dev);
-							return false;
-						}
+				devices.some(function (dev) {
+					if (dev.udid === udid) {
+						devHandle = appc.util.mix({}, dev);
 						return true;
-					});
+					}
+					return false;
 				});
 
 				if (!devHandle) {
-					err = new Error(__('Unable to find an Windows Phone device with the UDID "%s"', options.udid));
+					err = new Error(__('Unable to find a Windows Phone device with the UDID "%s"', udid));
 				}
+			} else if (devices.length) {
+				devHandle = appc.util.mix({}, devices[0]);
 			} else {
-				Object.keys(devInfo).filter(function (wpsdk) {
-					return !options.wpsdk || wpsdk === options.wpsdk;
-				}).some(function (wpsdk) {
-					if (devInfo[wpsdk].devices.length) {
-						devHandle = appc.util.mix({}, devInfo[wpsdk].devices[0]);
-						return true;
-					}
-				});
-
-				if (!devHandle) {
-					// user experience!
-					if (options.wpsdk) {
-						err = new Error(__('Unable to find an Windows Phone %s device.', options.wpsdk));
-					} else {
-						err = new Error(__('Unable to find an Windows Phone device.'));
-					}
+				// user experience!
+				if (options.wpsdk) {
+					err = new Error(__('Unable to find a Windows Phone %s device.', options.wpsdk));
+				} else {
+					err = new Error(__('Unable to find a Windows Phone device.'));
 				}
 			}
 
@@ -182,7 +170,9 @@ function install(udid, appPath, options, callback) {
 					emitter.emit('error', err);
 					return callback(err);
 				})
-				.on('connected', function () {
+				.on('connected', function (dev) {
+					devHandle.ip = dev.ip; // copy the IP address we got from connecting
+					devHandle.running = dev.running || true; // copy running status we got from connecting
 					// device is good to go, install the app!
 					var timeout = options.timeout !== void 0 && Math.max(~~options.timeout, 1000); // minimum of 1 second
 					wptool.install(devHandle, appPath, appc.util.mix({timeout: timeout}, options))

--- a/lib/device.js
+++ b/lib/device.js
@@ -172,7 +172,7 @@ function install(udid, appPath, options, callback) {
 				})
 				.on('connected', function (dev) {
 					devHandle.ip = dev.ip; // copy the IP address we got from connecting
-					devHandle.running = dev.running || true; // copy running status we got from connecting
+					devHandle.running = dev.running || true; // copy running status we got fromc onnecting
 					// device is good to go, install the app!
 					var timeout = options.timeout !== void 0 && Math.max(~~options.timeout, 1000); // minimum of 1 second
 					wptool.install(devHandle, appPath, appc.util.mix({timeout: timeout}, options))

--- a/lib/emulator.js
+++ b/lib/emulator.js
@@ -99,7 +99,7 @@ function isRunning(udid, options, callback) {
 					return callback(ex);
 				}
 
-				wptool.enumerate(options)
+				wptool.enumerate(options) // TODO Use detect so we can re-use the cache?
 					.on('error', function (err) {
 						emitter.emit('error', err);
 						callback(err);
@@ -171,7 +171,7 @@ function isRunning(udid, options, callback) {
  */
 function launch(udid, options, callback) {
 	return magik(options, callback, function (emitter, options, callback) {
-		// detect emulators
+		// detect emulators // FIXME Use detect so we can re-use the cache!
 		wptool.enumerate(options, function (err, emuInfo) {
 			if (err) {
 				emitter.emit('error', err);
@@ -253,8 +253,9 @@ function launch(udid, options, callback) {
 					}).on('error', function (err) {
 						emitter.emit('error', err);
 						callback(err);
-					}).on('connected', function () {
-						emuHandle.running = true;
+					}).on('connected', function (emu) {
+						emuHandle.ip = emu.ip; // copy IP address we got from connecting
+						emuHandle.running = emu.running || true;
 						emitter.emit('launched', emuHandle);
 						callback(null, emuHandle);
 					}).on('timeout', function (err) {

--- a/lib/emulator.js
+++ b/lib/emulator.js
@@ -99,7 +99,7 @@ function isRunning(udid, options, callback) {
 					return callback(ex);
 				}
 
-				wptool.enumerate(options) // TODO Use detect so we can re-use the cache?
+				wptool.enumerate(options) // TODO USe detect so we can re-use the cache!
 					.on('error', function (err) {
 						emitter.emit('error', err);
 						callback(err);

--- a/lib/wptool.js
+++ b/lib/wptool.js
@@ -400,7 +400,7 @@ function connect(udid, options, callback) {
 							emitter.emit(result || 'error', err);
 							return callback(err);
 						}
-						emitter.emit('connected');
+						emitter.emit('connected', result); // send along device info we have
 						callback(null, result);
 					};
 				if (wpsdk == '10.0') {
@@ -551,14 +551,14 @@ function wpToolConnect(device, options, callback) {
 		try {
 			var result = JSON.parse(out);
 			if (!result.success) {
-				var ex = new Error(__('Failed to conect to emulator'));
+				var ex = new Error(__('Failed to connect to %s', device.name));
 				return callback(ex);
 			}
 			device.ip = result.ip;
 			device.running = true; // mark it as running so we don't try and launch it again via connect
 			callback(null, device);
 		} catch (e) {
-			var ex = new Error(__('Failed to conect to emulator'));
+			var ex = new Error(__('Failed to connect to %s', device.name));
 			callback(ex);
 		}
 	});
@@ -566,7 +566,7 @@ function wpToolConnect(device, options, callback) {
 		abortTimer = setTimeout(function () {
 			child.kill();
 
-			var ex = new Error(__('Timed out after %d milliseconds trying to connect to %s', options.timeout, device.type));
+			var ex = new Error(__('Timed out after %d milliseconds trying to connect to %s', options.timeout, device.name));
 			callback(ex, 'timeout');
 		}, options.timeout);
 	}
@@ -870,7 +870,6 @@ function install(device, appPath, options, callback) {
 						if (err) {
 							return callback(err);
 						}
-						// now launch it!
 						wpToolLaunch(device, guid, options, function (err, result) {
 							if (err) {
 								emitter.emit(result || 'error', err);
@@ -881,7 +880,7 @@ function install(device, appPath, options, callback) {
 						});
 					});
 				} else {
-					// We're just installing. No need to grab appid or laucnh the app
+					// We're just installing. No need to grab appid or launch the app
 					wpToolInstall(cmd, device, appPath, options, function (err, result) {
 						if (err) {
 							emitter.emit(result || 'error', err);

--- a/lib/wptool.js
+++ b/lib/wptool.js
@@ -31,7 +31,8 @@ const
 	// this is a hard coded list of emulators to detect.
 	// when the next windows phone is released, the enumerate()
 	// function will need to detect the new emulators.
-	wpsdks = ['8.0', '8.1', '10.0'];
+	wpsdks = ['8.0', '8.1', '10.0'],
+	PREFERRED_SDK = '10.0'; // ultimate fallback sdk version to use by default
 
 var cache;
 
@@ -94,9 +95,7 @@ function parseWinAppDeployCmdListing(out) {
 	while ((match = deviceListingRE.exec(out)) !== null)
 	{
 		// TODO How can we know what SDK is on the phone? My win 8.1U1 phone shows up in listings when connected via USB
-		// We're going to make a giant assumption that it's 10 since we saw it on the 10 tooling.
-		// BUT!!!! We do see 8.1 devices here. And I think we'll bomb out badly if a user has a win 8.1 phone
-		devices.push({name: match[5], udid: match[3], index: i, wpsdk: '10.0', ip: match[1]});
+		devices.push({name: match[5], udid: match[3], index: i, wpsdk: null, ip: match[1]});
 		i++;
 	}
 
@@ -261,7 +260,7 @@ function nativeEnumerate(wpsdk, options, next) {
 			} else {
 				var emulators = parseAppDeployCmdListing(out, wpsdk);
 				next(null, {
-					devices: [{name: 'Device', udid:  wpsdk.split(/\./).join('-') + '-0', index: 0, wpsdk: wpsdk}],
+					devices: [{name: 'Device', udid: 0, index: 0, wpsdk: null}],
 					emulators: emulators
 				});
 			}
@@ -269,6 +268,13 @@ function nativeEnumerate(wpsdk, options, next) {
 	});
 }
 
+/**
+ * Detects Windows Phone devices and emulators.
+ *
+ * @param {Object} [options] - An object containing various settings.
+ * @param {Boolean} [options.bypassCache=false] - When true, re-detects all Windows Phone devices.
+ * @param {Function} [callback(err, results)] - A function to call with the device/emulator information.
+ */
 function detect(options, callback) {
 	return enumerate(options, function (err, results) {
 		var result = {
@@ -290,6 +296,24 @@ function detect(options, callback) {
 					}
 				});
 			});
+
+			// If we have a device with udid of 0 and non-null wpsdk _and_
+			// we have a device with real udid we got from WinAppDeployCmd, combine the listings!
+			var wpsdkIndex = result.devices.findIndex(function (dev) {
+				return dev.udid == 0 && dev.wpsdk;
+			});
+			if (wpsdkIndex != -1) {
+				// now find with "real" device
+				var realDeviceIndex = result.devices.findIndex(function (dev) {
+					return dev.udid != 0 && !dev.wpsdk;
+				});
+				if (realDeviceIndex != -1) {
+					// set 'real' device wpsdk to the value we got from wptool binary
+					result.devices[realDeviceIndex].wpsdk = result.devices[wpsdkIndex].wpsdk;
+					// remove the wptool binary entry
+					result.devices.splice(deviceWithWPSDK, 1);
+				}
+			}
 		}
 
 		callback(err, result);
@@ -330,7 +354,7 @@ function enumerate(options, callback) {
 						// Then later if we have no results for any version, we propagate the error
 						if (!results[wpsdk]) {
 							results[wpsdk] = {
-								devices: [{name: 'Device', udid: wpsdk.split(/\./).join('-') + '-0', index: 0, wpsdk: wpsdk}],
+								devices: [{name: 'Device', udid: 0, index: 0, wpsdk: null}],
 								emulators: [],
 							};
 						}
@@ -424,7 +448,7 @@ function connect(udid, options, callback) {
 					return callback(err);
 				}
 				// TODO if we have win 10 use it's deploy tool to push to devices?
-				var wpsdk = dev.wpsdk || options.wpsdk || options.preferredWindowsPhoneSDK || '8.1',
+				var wpsdk = dev.wpsdk || options.wpsdk || options.preferredWindowsPhoneSDK || PREFERRED_SDK,
 					done = function (err, result) {
 						if (err) {
 							emitter.emit(result || 'error', err);
@@ -655,7 +679,7 @@ function nativeLaunch(device, appid, options, callback) {
 			return callback(err);
 		}
 
-		var wpsdk = device.wpsdk || options.wpsdk || options.preferredWindowsPhoneSDK || '8.1',
+		var wpsdk = device.wpsdk || options.wpsdk || options.preferredWindowsPhoneSDK || PREFERRED_SDK,
 			deployCmd = phoneResults.windowsphone[wpsdk].deployCmd,
 			args = [
 				'/launch',
@@ -860,7 +884,7 @@ function install(device, appPath, options, callback) {
 				return callback(err);
 			}
 
-			var wpsdk = device.wpsdk || options.wpsdk || options.preferredWindowsPhoneSDK || '8.1',
+			var wpsdk = device.wpsdk || options.wpsdk || options.preferredWindowsPhoneSDK || PREFERRED_SDK,
 				cmd = phoneResults.windowsphone[wpsdk].deployCmd;
 			if (!cmd) {
 				var ex = new Error(__('Windows Phone SDK v%s does not appear to have an App deploy tool.', wpsdk));

--- a/lib/wptool.js
+++ b/lib/wptool.js
@@ -38,6 +38,7 @@ var cache;
 exports.enumerate = enumerate;
 exports.connect = connect;
 exports.install = install;
+exports.detect = detect;
 // expose some methods for unit testing
 exports.test = {
 	parseWinAppDeployCmdListing: parseWinAppDeployCmdListing,
@@ -93,7 +94,9 @@ function parseWinAppDeployCmdListing(out) {
 	while ((match = deviceListingRE.exec(out)) !== null)
 	{
 		// TODO How can we know what SDK is on the phone? My win 8.1U1 phone shows up in listings when connected via USB
-		devices.push({name: match[5], udid: match[3], index: i, wpsdk: null, ip: match[1]});
+		// We're going to make a giant assumption that it's 10 since we saw it on the 10 tooling.
+		// BUT!!!! We do see 8.1 devices here. And I think we'll bomb out badly if a user has a win 8.1 phone
+		devices.push({name: match[5], udid: match[3], index: i, wpsdk: '10.0', ip: match[1]});
 		i++;
 	}
 
@@ -258,11 +261,38 @@ function nativeEnumerate(wpsdk, options, next) {
 			} else {
 				var emulators = parseAppDeployCmdListing(out, wpsdk);
 				next(null, {
-					devices: [{name: 'Device', udid: 0, index: 0, wpsdk: null}],
+					devices: [{name: 'Device', udid:  wpsdk.split(/\./).join('-') + '-0', index: 0, wpsdk: wpsdk}],
 					emulators: emulators
 				});
 			}
 		});
+	});
+}
+
+function detect(options, callback) {
+	return enumerate(options, function (err, results) {
+		var result = {
+			emulators: {},
+			devices: [],
+			issues: []
+		},
+		tmp = {};
+
+		if (!err) {
+			Object.keys(results).forEach(function (wpsdk) {
+				result.emulators[wpsdk] = results[wpsdk].emulators;
+				results[wpsdk].devices.forEach(function (dev) {
+					if (!tmp[dev.udid]) {
+						tmp[dev.udid] = result.devices.length+1;
+						result.devices.push(dev);
+					} else if (dev.wpsdk) {
+						result.devices[tmp[dev.udid]-1] = dev;
+					}
+				});
+			});
+		}
+
+		callback(err, result);
 	});
 }
 
@@ -300,7 +330,7 @@ function enumerate(options, callback) {
 						// Then later if we have no results for any version, we propagate the error
 						if (!results[wpsdk]) {
 							results[wpsdk] = {
-								devices: [{name: 'Device', udid: 0, index: 0, wpsdk: null}],
+								devices: [{name: 'Device', udid: wpsdk.split(/\./).join('-') + '-0', index: 0, wpsdk: wpsdk}],
 								emulators: [],
 							};
 						}
@@ -403,6 +433,7 @@ function connect(udid, options, callback) {
 						emitter.emit('connected', result); // send along device info we have
 						callback(null, result);
 					};
+
 				if (wpsdk == '10.0') {
 					// if win10, just call connect on our native tool!
 					wpToolConnect(dev, options, done);
@@ -870,6 +901,7 @@ function install(device, appPath, options, callback) {
 						if (err) {
 							return callback(err);
 						}
+						// now launch it!
 						wpToolLaunch(device, guid, options, function (err, result) {
 							if (err) {
 								emitter.emit(result || 'error', err);

--- a/lib/wptool.js
+++ b/lib/wptool.js
@@ -311,7 +311,7 @@ function detect(options, callback) {
 					// set 'real' device wpsdk to the value we got from wptool binary
 					result.devices[realDeviceIndex].wpsdk = result.devices[wpsdkIndex].wpsdk;
 					// remove the wptool binary entry
-					result.devices.splice(deviceWithWPSDK, 1);
+					result.devices.splice(wpsdkIndex, 1);
 				}
 			}
 		}
@@ -344,7 +344,7 @@ function enumerate(options, callback) {
 				errors = [];
 
 			// wpsdks is a constant above that contains all supported Windows Phone SDK versions
-			async.eachSeries(wpsdks, function (wpsdk, next) {
+			async.each(wpsdks, function (wpsdk, next) {
 				// We use our custom tool for Win 10, the native tooling for 8.x
 				var funcToCall = (wpsdk == '10.0') ? wptoolEnumerate : nativeEnumerate;
 

--- a/wptool/wptool.cs
+++ b/wptool/wptool.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Reflection;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -107,7 +107,7 @@ namespace wptool
 						}
 						Console.WriteLine("\t\t{\n");
 						Console.WriteLine("\t\t\t\"name\": \"" + dev.Name.Replace("\"", "\\\"") + "\",");
-						Console.WriteLine("\t\t\t\"udid\": " + id + ",");
+						Console.WriteLine("\t\t\t\"udid\": \"" + wpsdk.Replace('.', '-') + "-" + id + "\",");
 						Console.WriteLine("\t\t\t\"index\": " + id + ",");
 						Console.WriteLine("\t\t\t\"version\": \"" + versionString + "\","); // windows 8.1: "6.3", windows 10: "10.0"
 						Console.WriteLine("\t\t\t\"wpsdk\": " + sdk);

--- a/wptool/wptool.cs
+++ b/wptool/wptool.cs
@@ -107,7 +107,7 @@ namespace wptool
 						}
 						Console.WriteLine("\t\t{\n");
 						Console.WriteLine("\t\t\t\"name\": \"" + dev.Name.Replace("\"", "\\\"") + "\",");
-						Console.WriteLine("\t\t\t\"udid\": \"" + wpsdk.Replace('.', '-') + "-" + id + "\",");
+						Console.WriteLine("\t\t\t\"udid\": " + id + ",");
 						Console.WriteLine("\t\t\t\"index\": " + id + ",");
 						Console.WriteLine("\t\t\t\"version\": \"" + versionString + "\","); // windows 8.1: "6.3", windows 10: "10.0"
 						Console.WriteLine("\t\t\t\"wpsdk\": " + sdk);


### PR DESCRIPTION
- When installing app to device, don't re-enumerate the devices, use the cached listing if possible
- fix error message when unable to find device with same udid (udid was always reported as undefined before)
- retain device ip/running flag after connecting in install (to avoid need to connect again)
- pass device/emulator object along with 'connected' event
- Add some FIXME markers