### PR TITLE
[TIMOB-23279] Only report a device when one has been detected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+0.4.15 (7/13/2016)
+-------------------
+  * [TIMOB-23279] Only report detected device 
+
 0.4.14 (6/24/2016)
 -------------------
   * [TIMOB-23484] wptool.detect() ignore errors when results are present

--- a/lib/wptool.js
+++ b/lib/wptool.js
@@ -352,8 +352,8 @@ function enumerate(options, callback) {
 
 			// wpsdks is a constant above that contains all supported Windows Phone SDK versions
 			async.eachSeries(wpsdks, function (wpsdk, next) {
-				// We use our custom tool for Win 10, the native tooling for 8.x
-				var funcToCall = (wpsdk == '10.0') ? wptoolEnumerate : nativeEnumerate;
+				// Use custom wptool for 10.0 and 8.1, use native tooling for 8.0
+				var funcToCall = (wpsdk != '8.0') ? wptoolEnumerate : nativeEnumerate;
 
 				funcToCall(wpsdk, options, function (err, result) {
 					if (err) {
@@ -361,7 +361,7 @@ function enumerate(options, callback) {
 						// Then later if we have no results for any version, we propagate the error
 						if (!results[wpsdk]) {
 							results[wpsdk] = {
-								devices: [{name: 'Device', udid: 0, index: 0, wpsdk: null}],
+								devices: [],
 								emulators: [],
 							};
 						}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "windowslib",
-	"version": "0.4.14",
+	"version": "0.4.15",
 	"description": "Windows Phone Utility Library",
 	"keywords": [
 		"appcelerator",

--- a/wptool/wptool.cs
+++ b/wptool/wptool.cs
@@ -104,6 +104,9 @@ namespace wptool
 							sdk = "\"8.1\"";
 						} else if (versionString == "10.0") {
 							sdk = "\"10.0\"";
+						// skip invalid device
+						} else if (versionString.StartsWith("2147483647")) {
+							continue;
 						}
 						Console.WriteLine("\t\t{\n");
 						Console.WriteLine("\t\t\t\"name\": \"" + dev.Name.Replace("\"", "\\\"") + "\",");


### PR DESCRIPTION
- If a device has not been detected then no devices should be reported
- Skip any invalid devices detected by ``wptool`` (such as two devices at once, which is unsupported)
- Use ``wptool`` with ``8.1`` and ``10.0`` but not ``8.0`` (which is now unsupported)

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-23279)