### PR TITLE
[TIMOB-23484] wptool.detect() ignore errors when results are present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+0.4.14 (6/24/2016)
+-------------------
+  * [TIMOB-23484] wptool.detect() ignore errors when results are present
+
 0.4.13 (4/29/2016)
 -------------------
   * Fix [TIMOB-20376] Windows Phone: Cannot read property 'split' of undefined

--- a/lib/wptool.js
+++ b/lib/wptool.js
@@ -284,7 +284,10 @@ function detect(options, callback) {
 		},
 		tmp = {};
 
-		if (!err) {
+		if (err && !results) {
+			// detected an error with no results
+			callback(err);
+		} else {
 			Object.keys(results).forEach(function (wpsdk) {
 				result.emulators[wpsdk] = results[wpsdk].emulators;
 				results[wpsdk].devices.forEach(function (dev) {
@@ -320,7 +323,7 @@ function detect(options, callback) {
 			}
 		}
 
-		callback(err, result);
+		callback(null, result);
 	});
 }
 
@@ -379,7 +382,7 @@ function enumerate(options, callback) {
 					return results[wpsdk].emulators.length > 0;
 				})) {
 					emitter.emit('error', errors[0]);
-					return callback(errors[0]);
+					return callback(errors[0], results);
 				}
 
 				// add a helper function to get a device by udid

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "windowslib",
-	"version": "0.4.13",
+	"version": "0.4.14",
 	"description": "Windows Phone Utility Library",
 	"keywords": [
 		"appcelerator",


### PR DESCRIPTION
- Prevent ``wptool.detect()`` from passing errors when a usable result is still obtainable

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-23484)