### PR TITLE
[TIMOB-23371] Remove placeholder device when detecting emulators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+0.4.16 (7/19/2016)
+-------------------
+  * [TIMOB-23371] Remove placeholder device when only detecting emulators
+
 0.4.15 (7/13/2016)
 -------------------
   * [TIMOB-23279] Only report detected device 

--- a/lib/wptool.js
+++ b/lib/wptool.js
@@ -260,7 +260,7 @@ function nativeEnumerate(wpsdk, options, next) {
 			} else {
 				var emulators = parseAppDeployCmdListing(out, wpsdk);
 				next(null, {
-					devices: [{name: 'Device', udid: 0, index: 0, wpsdk: null}],
+					devices: [],
 					emulators: emulators
 				});
 			}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "windowslib",
-	"version": "0.4.15",
+	"version": "0.4.16",
 	"description": "Windows Phone Utility Library",
 	"keywords": [
 		"appcelerator",


### PR DESCRIPTION
- Remove placeholder ``Device````udid: 0`` when ``nativeEnumerate`` only detects emulators
- Supported devices should be detected with the ``wptool``
- Prevents a device always showing when one is not connected

```
Which device do you want to install your app on?
   1)  Device                    (udid: 0)    # this placeholder is not needed
   2)  Lumia 930 (RM-1045)       (udid: 00000015-4e57-1877-0000-000000000000)
   3)  Nokia Lumia 520 (RM-914)  (udid: 004a0090-40df-0094-0000-000000000000)
Select by number or name [Device]: 
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-23371)