### PR TITLE
[TIMOB-23748] Failed to connect to WP 8.1 device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+0.4.16 (8/9/2016)
+-------------------
+  * [TIMOB-23748] Fix: Failed to connect to WP 8.1 device
+
 0.4.15 (7/13/2016)
 -------------------
   * [TIMOB-23279] Only report detected device 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "windowslib",
-	"version": "0.4.15",
+	"version": "0.4.16",
 	"description": "Windows Phone Utility Library",
 	"keywords": [
 		"appcelerator",

--- a/wptool/wptool.cs
+++ b/wptool/wptool.cs
@@ -174,18 +174,6 @@ namespace wptool
 					return showHelp(String.Format("Invalid device UDID '{0:D}'", udid));
 				}
 
-				// ConnectableDevice throws an error when connecting to a physical Windows 10 device
-				// physical Windows 10 devices can be connected to using 127.0.0.1
-				if (command == "connect" && connectableDevice.Version.Major == 10 && !connectableDevice.IsEmulator())
-				{
-					Console.WriteLine("{");
-					Console.WriteLine("\t\"success\": true,");
-					Console.WriteLine("\t\"ip\": \"127.0.0.1\",");
-					Console.WriteLine("\t\"osVersion\": \"" + connectableDevice.Version.ToString() + "\"");
-					Console.WriteLine("}");
-					return 0;
-				}
-
 				try {
 					IDevice device = connectableDevice.Connect();
 
@@ -197,27 +185,45 @@ namespace wptool
 						Console.WriteLine("\t\"success\": true");
 						Console.WriteLine("}");
 					} else {
-						string destinationIp;
-						string sourceIp;
-						int destinationPort;
-						device.GetEndPoints(0, out sourceIp, out destinationIp, out destinationPort);
-						var address = IPAddress.Parse(destinationIp);
-						ISystemInfo systemInfo = device.GetSystemInfo();
+						try {
+							string destinationIp;
+							string sourceIp;
+							int destinationPort;
+							device.GetEndPoints(0, out sourceIp, out destinationIp, out destinationPort);
+							var address = IPAddress.Parse(destinationIp);
+							ISystemInfo systemInfo = device.GetSystemInfo();
 
-						Version version = new Version(systemInfo.OSMajor, systemInfo.OSMinor, systemInfo.OSBuildNo);
-						Console.WriteLine("{");
-						Console.WriteLine("\t\"success\": true,");
-						Console.WriteLine("\t\"ip\": \"" + address.ToString() + "\",");
-						Console.WriteLine("\t\"port\": " + destinationPort.ToString() + ",");
-						Console.WriteLine("\t\"osVersion\": \"" + version.ToString() + "\",");
-						Console.WriteLine("\t\"availablePhysical\": " + systemInfo.AvailPhys.ToString() + ",");
-						Console.WriteLine("\t\"totalPhysical\": " + systemInfo.TotalPhys.ToString() + ",");
-						Console.WriteLine("\t\"availableVirtual\": " + systemInfo.AvailVirtual.ToString() + ",");
-						Console.WriteLine("\t\"totalVirtual\": " + systemInfo.TotalVirtual.ToString() + ",");
-						Console.WriteLine("\t\"architecture\": \"" + systemInfo.ProcessorArchitecture.ToString() + "\",");
-						Console.WriteLine("\t\"instructionSet\": \"" + systemInfo.InstructionSet.ToString() + "\",");
-						Console.WriteLine("\t\"processorCount\": " + systemInfo.NumberOfProcessors.ToString() + "");
-						Console.WriteLine("}");
+							Version version = new Version(systemInfo.OSMajor, systemInfo.OSMinor, systemInfo.OSBuildNo);
+							Console.WriteLine("{");
+							Console.WriteLine("\t\"success\": true,");
+							Console.WriteLine("\t\"ip\": \"" + address.ToString() + "\",");
+							Console.WriteLine("\t\"port\": " + destinationPort.ToString() + ",");
+							Console.WriteLine("\t\"osVersion\": \"" + version.ToString() + "\",");
+							Console.WriteLine("\t\"availablePhysical\": " + systemInfo.AvailPhys.ToString() + ",");
+							Console.WriteLine("\t\"totalPhysical\": " + systemInfo.TotalPhys.ToString() + ",");
+							Console.WriteLine("\t\"availableVirtual\": " + systemInfo.AvailVirtual.ToString() + ",");
+							Console.WriteLine("\t\"totalVirtual\": " + systemInfo.TotalVirtual.ToString() + ",");
+							Console.WriteLine("\t\"architecture\": \"" + systemInfo.ProcessorArchitecture.ToString() + "\",");
+							Console.WriteLine("\t\"instructionSet\": \"" + systemInfo.InstructionSet.ToString() + "\",");
+							Console.WriteLine("\t\"processorCount\": " + systemInfo.NumberOfProcessors.ToString() + "");
+							Console.WriteLine("}");
+						} catch (Exception ex) {
+							//
+							// ConnectableDevice throws an error when connecting to a physical Windows 10 device
+							// physical Windows 10 devices can be connected to using 127.0.0.1.
+							// From some point of Windows 10 SDK, IDevice.GetEndPoints throws Exception for Windows Phone 8.1 device too.
+							// Interestingly ConnectableDevice.Version returns 8.1 _or_ 6.3 in this case.
+							// Returning ok for now because we can still connect to the device.
+							//
+							if (command == "connect" && !connectableDevice.IsEmulator()) {
+								Console.WriteLine("{");
+								Console.WriteLine("\t\"success\": true,");
+								Console.WriteLine("\t\"ip\": \"127.0.0.1\",");
+								Console.WriteLine("\t\"osVersion\": \"" + connectableDevice.Version.ToString() + "\"");
+								Console.WriteLine("}");
+								return 0;
+							}
+						}
 					}
 					return 0;
 				} catch (Exception ex) {


### PR DESCRIPTION
[TIMOB-23748](https://jira.appcelerator.org/browse/TIMOB-23748)

Titanium CLI is unable to connect to Windows Phone 8.1 device after updating to Microsoft Windows 10 SDK `10.0.14393`. There's no problem building against Windows 10 Mobile device though.

![vs](https://cloud.githubusercontent.com/assets/1661068/17504887/e503dcee-5e37-11e6-9fc8-7bcc06475ecc.png)

As far as I can see, it turns out that `Microsoft.SmartDevice.Connectivity.IDevice.GetEndPoints` throws Exception when you connect to Windows Phone 8.1 device. I found that it actually is able to connect to WP 8.1 device, and those information (that `IDevice.GetEndPoints` collects) are not actually used from Titanium CLI, so it's safe to return success=true.
