### PR TITLE
[TIMOB-23749] "appc ti info" does not list WP 8.1 emulators

### DIFF
--- a/lib/wptool.js
+++ b/lib/wptool.js
@@ -149,7 +149,11 @@ function wptoolEnumerate(wpsdk, options, next) {
 		async.parallel([
 			// discover windows 10 devices in network using WinAppDeployCmd
 			function (cb) {
-				winAppDeployCmdEnumerate(phoneResults.windowsphone[wpsdk].deployCmd, cb);
+				if (wpsdk == '10.0') {
+					winAppDeployCmdEnumerate(phoneResults.windowsphone[wpsdk].deployCmd, cb);
+				} else {
+					nativeEnumerate(wpsdk, options, cb);
+				}
 			},
 			// Use our custom wptool binary to gather Windows 10 emulators
 			function (cb) {


### PR DESCRIPTION
[TIMOB-23749](https://jira.appcelerator.org/browse/TIMOB-23749)

`appc ti info -p windows -o json` does not list Windows Phone 8.1 emulators. 

*Steps to reproduce*

`appc ti info -p windows -o json`

*Expected*

Windows Phone 8.1 emulators are listed as well as Windows 10 Mobile emulators.