### PR TITLE
[TIMOB-23762] Handle duplicate package error from Windows SDK 10.0.14393

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+0.4.18 (8/12/2016)
+-------------------
+  * [TIMOB-23762] Handle duplicate package error from Windows SDK 10.0.14393
+
 0.4.17 (8/12/2016)
 -------------------
   * [TIMOB-23768] Detect installed Win10 SDK versions

--- a/lib/wptool.js
+++ b/lib/wptool.js
@@ -830,9 +830,15 @@ function wpToolInstall(deployCmd, device, appPath, options, callback) {
 		clearTimeout(abortTimer);
 
 		if (code) {
-			var errmsg = out.trim().split(/\r\n|\n/).shift(),
-				ex = new Error(/^Error: /.test(errmsg) ? errmsg.substring(7) : __('Failed to install app (code %s): %s', code, out));
-			callback(ex);
+			// handle duplicate package identity error code from Windows 10.0.14393 tooling and above
+			if (code == '2148734208') {
+				options.forceUnInstall = true;
+				wpToolInstall(deployCmd, device, appPath, options, callback);
+			} else {
+				var errmsg = out.trim().split(/\r\n|\n/).shift(),
+					ex = new Error(/^Error: /.test(errmsg) ? errmsg.substring(7) : __('Failed to install app (code %s): %s', code, out));
+				callback(ex);
+			}
 		} else {
 			var errmsg = /failed\. (\w*)\r?\n(.*)/.exec(out);
 			if (errmsg) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "windowslib",
-	"version": "0.4.17",
+	"version": "0.4.18",
 	"description": "Windows Phone Utility Library",
 	"keywords": [
 		"appcelerator",


### PR DESCRIPTION
- Take appropriate action when handling duplicate package error `[ERROR] Error: Failed to install app (code 2148734208): Windows App Deployment Tool` caused by Windows SDK `10.0.14393`

###### TEST CASE
```
# deploy app to Windows 10 device
appc run -p windows -T wp-device

# attempt to deploy app to device again
appc run -p windows -T wp-device
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-23762)