### PR TITLE
[TIMOB-23800] CLI hangs on install of app when a different app installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+0.4.19 (8/23/2016)
+-------------------
+  * [TIMOB-23800] CLI hangs on install of app when a different app is installed
+
 0.4.18 (8/12/2016)
 -------------------
   * [TIMOB-23762] Handle duplicate package error from Windows SDK 10.0.14393

--- a/lib/wptool.js
+++ b/lib/wptool.js
@@ -832,8 +832,13 @@ function wpToolInstall(deployCmd, device, appPath, options, callback) {
 		if (code) {
 			// handle duplicate package identity error code from Windows 10.0.14393 tooling and above
 			if (code == '2148734208') {
-				options.forceUnInstall = true;
-				wpToolInstall(deployCmd, device, appPath, options, callback);
+				if (out.indexOf('because the current user does not have that package installed') == -1) {
+					options.forceUnInstall = true;
+					wpToolInstall(deployCmd, device, appPath, options, callback);
+				} else {
+					// Windows cannot remove the app because the current user does not have that package installed.
+					callback(new Error('A debug application is already installed, please remove existing debug application'));
+				}
 			} else {
 				var errmsg = out.trim().split(/\r\n|\n/).shift(),
 					ex = new Error(/^Error: /.test(errmsg) ? errmsg.substring(7) : __('Failed to install app (code %s): %s', code, out));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "windowslib",
-	"version": "0.4.18",
+	"version": "0.4.19",
 	"description": "Windows Phone Utility Library",
 	"keywords": [
 		"appcelerator",


### PR DESCRIPTION
[TIMOB-23800](https://jira.appcelerator.org/browse/TIMOB-23800)

*Steps to reproduce*

- Build an application to a Windows mobile device or emulator
- Without uninstalling the previous app, build a different app to a Windows mobile device or emulator

*Expected result*

As with previous SDKs the CLI should log an error to the user telling them to uninstall the other app