### PR TITLE
[TIMOB-23834] Implement ability to skip windows phone device detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+0.4.21 (8/26/2016)
+-------------------
+  * [TIMOB-23834] Ability to skip windows phone detection
+
 0.4.20 (8/26/2016)
 -------------------
   * [TIMOB-23816] Fix 8.1 emulator listing

--- a/index.js
+++ b/index.js
@@ -42,6 +42,7 @@ exports.version  = packageJson.version;
  *
  * @param {Object} [options] - An object containing various settings.
  * @param {Boolean} [options.bypassCache=false] - When true, re-detects the all Windows phone information.
+ * @param {Boolean} [options.skipWpTool=false] - When true, skips detection of Windows phone.
  * @param {String} [options.assemblyPath=%WINDIR%\Microsoft.NET\assembly\GAC_MSIL] - Path to .NET global assembly cache.
  * @param {String} [options.powershell] - Path to the <code>powershell</code> executable.
  * @param {String} [options.preferredWindowsPhoneSDK] - The preferred version of the Windows Phone SDK to use by default. Example "8.0".
@@ -61,11 +62,21 @@ function detect(options, callback) {
 		}
 
 		var results = {
-			detectVersion: '3.0',
-			issues: []
-		};
+				detectVersion: '3.0',
+				issues: []
+			},
+			libs = [
+				env,
+				visualstudio,
+				windowsphone,
+				assemblies,
+				winstore
+			];
 
-		async.each([env, visualstudio, windowsphone, assemblies, winstore, wptool], function (lib, next) {
+		if (!options.skipWpTool) {
+			libs.push(wptool);
+		}
+		async.each(libs, function (lib, next) {
 			lib.detect(options, function (err, result) {
 				err || mix(result, results);
 				next(err);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "windowslib",
-	"version": "0.4.20",
+	"version": "0.4.21",
 	"description": "Windows Phone Utility Library",
 	"keywords": [
 		"appcelerator",


### PR DESCRIPTION
- Implement `options.skipWpTool` to skip detection of Windows devices

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-23834)