### PR TITLE
[TIMOB-23661] Fix typo around preferred SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+0.4.22 (9/14/2016)
+-------------------
+  * [TIMOB-23661] Fix typo around preferred SDK
+
 0.4.21 (8/26/2016)
 -------------------
   * [TIMOB-23834] Ability to skip windows phone detection

--- a/lib/windowsphone.js
+++ b/lib/windowsphone.js
@@ -248,7 +248,7 @@ function detect(options, callback) {
 					return finalize();
 				}
 
-				var preferred = options.preferred;
+				var preferred = options.preferredWindowsPhoneSDK;
 				if (!results.windowsphone[preferred] || !results.windowsphone[preferred].supported) {
 					preferred = Object.keys(results.windowsphone).filter(function (v) { return results.windowsphone[v].supported; }).sort().pop();
 				}

--- a/lib/winstore.js
+++ b/lib/winstore.js
@@ -471,7 +471,7 @@ function detect(options, callback) {
 					}
 				}
 
-				var preferred = options.preferred;
+				var preferred = options.preferredWindowsSDK;
 				if (!results.windows[preferred] || !results.windows[preferred].supported) {
 					preferred = Object.keys(results.windows).filter(function (v) { return results.windows[v].supported; }).sort().pop();
 				}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "windowslib",
-	"version": "0.4.21",
+	"version": "0.4.22",
 	"description": "Windows Phone Utility Library",
 	"keywords": [
 		"appcelerator",


### PR DESCRIPTION
Related to [TIMOB-23661](https://jira.appcelerator.org/browse/TIMOB-23661)

`preferredWindowsPhoneSDK` and `preferredWindowsSDK` should be the valid options to specify preferred Windows SDK version.