### PR TITLE
[TIMOB-23879] Terminate running app at launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+0.4.23 (9/16/2016)
+-------------------
+  * [TIMOB-23879] Terminate running app at launch
+
 0.4.22 (9/14/2016)
 -------------------
   * [TIMOB-23661] Fix typo around preferred SDK

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "windowslib",
-	"version": "0.4.22",
+	"version": "0.4.23",
 	"description": "Windows Phone Utility Library",
 	"keywords": [
 		"appcelerator",

--- a/wptool/wptool.cs
+++ b/wptool/wptool.cs
@@ -180,6 +180,7 @@ namespace wptool
 					if (command == "launch")
 					{
 						IRemoteApplication app = device.GetApplication(appid);
+						app.TerminateRunningInstances();
 						app.Launch();
 						Console.WriteLine("{");
 						Console.WriteLine("\t\"success\": true");


### PR DESCRIPTION
[TIMOB-23879](https://jira.appcelerator.org/browse/TIMOB-23879)

Make sure to terminate running app on launch. Interestingly terminating app right before _launch_ refreshes the app.

Steps to reproduce

1. Build an app using `appc run -p windows -T wp-device`
2. Once the app has launched, quit the process and *leave the app open on device*
3. Make an obvious change in the app, such as changing the background color
4. Rebuild the app `appc run -p windows -T wp-device`
5. Observe the app

Expected

App should be launched with new state (new background color etc).
