### PR TITLE
[TIMOB-23976] enumerate should just move on when no results found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+0.4.24 (11/10/2016)
+-------------------
+  * [TIMOB-23976] enumerate should just move on even when no results with given version
+
 0.4.23 (9/16/2016)
 -------------------
   * [TIMOB-23879] Terminate running app at launch

--- a/lib/wptool.js
+++ b/lib/wptool.js
@@ -139,10 +139,9 @@ function wptoolEnumerate(wpsdk, options, next) {
 			return next(err);
 		}
 
-		// Just move on if we have no results for a given version?
 		if (!phoneResults.windowsphone[wpsdk]) {
-			var ex = new Error(__('Did not find support for WP SDK %s. Cannot enumerate devices.', wpsdk));
-			return next(ex);
+			// Just move on if we have no results for a given version
+			return next(null, {devices:[],emulators:[]});
 		}
 
 		// device discovery is slower, do it in parallel with emulator discovery/listing
@@ -227,10 +226,9 @@ function nativeEnumerate(wpsdk, options, next) {
 			return next(err, null);
 		}
 
-		// Just move on if we have no results for a given version?
 		if (!phoneResults.windowsphone[wpsdk]) {
-			var ex = new Error(__('Did not find support for WP SDK %s. Cannot enumerate devices.', wpsdk));
-			return next(ex, null);
+			// Just move on if we have no results for a given version
+			return next(null, {devices:[],emulators:[]});
 		}
 
 		if (!phoneResults.windowsphone[wpsdk].deployCmd) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "windowslib",
-	"version": "0.4.23",
+	"version": "0.4.24",
 	"description": "Windows Phone Utility Library",
 	"keywords": [
 		"appcelerator",


### PR DESCRIPTION
[TIMOB-23976](https://jira.appcelerator.org/browse/TIMOB-23976)

`enumerate` should just return empty data when no results found with given version. It is because we tend to `enumerate` across Windows SDK (8.0, 8.1, 10.0) with use of multiple ways (native tooling, ws, wptool) and we don't want to throw error when one of them returns no data.