### PR TITLE
[TIMOB-24157] Install certificate in new window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+0.4.24 (11/22/2016)
+-------------------
+  * [TIMOB-24157] Install certificate in new window
+
 0.4.23 (9/16/2016)
 -------------------
   * [TIMOB-23879] Terminate running app at launch

--- a/lib/winstore.js
+++ b/lib/winstore.js
@@ -88,7 +88,7 @@ function install(projectDir, options, callback) {
 				// Error codes 9 and 14 mean rerun without -Force
 				if ((code && (code == 9 || code == 14)) ||
 					out.indexOf('script without the -Force parameter') !== -1) {
-					appc.subprocess.run(options.powershell || 'powershell', ['-ExecutionPolicy', 'Bypass', '-NoLogo', '-NoProfile', '-File', psScript], function (code, out, err) {
+					require('child_process').exec((options.powershell || 'powershell') + ' -ExecutionPolicy Bypass -NoLogo -NoProfile -Command "Start-Process powershell -Wait -argument ' + psScript + '"', function(code, out, err) {
 						if (err) {
 							emitter.emit('error', err);
 							callback(err);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "windowslib",
-	"version": "0.4.23",
+	"version": "0.4.24",
 	"description": "Windows Phone Utility Library",
 	"keywords": [
 		"appcelerator",


### PR DESCRIPTION
[TIMOB-24157](https://jira.appcelerator.org/browse/TIMOB-24157)

When we install Windows Store app, we need to ensure developer certificate installed first, and then it needs to be executed in a new Window to workaround user-input issue in Node.js (described in the ticket).

To see if you already installed developer certificate, launch “Manage user certificates” from control panel and navigate to “Trusted People > Certificates”. “CMake Test Cert” is the developer cert. You can remove it in order to test this issue.

![60735_certmgr](https://cloud.githubusercontent.com/assets/1661068/20511199/6d7604ca-b0b9-11e6-8546-3fcda5bf9c15.png)

```
appc run -p windows --wp-sdk 10.0 --target ws-local -l trace
```