### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/logrelay.js
+++ b/lib/logrelay.js
@@ -16,7 +16,7 @@ const
 	EventEmitter = require('events').EventEmitter,
 	net = require('net'),
 	util = require('util'),
-	uuid = require('node-uuid'),
+	uuid = require('uuid'),
 	__ = appc.i18n(__dirname).__;
 
 module.exports = LogRelay;

--- a/package.json
+++ b/package.json
@@ -1,67 +1,81 @@
 {
-	"name": "windowslib",
-	"version": "0.4.23",
-	"description": "Windows Phone Utility Library",
-	"keywords": [
-		"appcelerator",
-		"windows",
-		"windows phone",
-		"winstore",
-		"windows store",
-		"visualstudio",
-		"visual studio",
-		"microsoft"
-	],
-	"author": {
-		"name": "Appcelerator, Inc.",
-		"email": "npmjs@appcelerator.com"
-	},
-	"maintainers": [
-		{"name": "Chris Barber", "email": "cbarber@appcelerator.com"},
-		{"name": "Chris Williams", "email": "cwilliams@appcelerator.com"},
-		{"name": "Dawson Toth", "email": "dtoth@appcelerator.com"},
-		{"name": "Kota Iguchi", "email": "kiguchi@appcelerator.com"}
-	],
-	"repository": {
-		"type": "git",
-		"url": "git://github.com/appcelerator/windowslib.git"
-	},
-	"license": "Apache Public License v2",
-	"main": "./index",
-	"bugs": {
-		"url": "https://github.com/appcelerator/windowslib/issues"
-	},
-	"directories": {
-		"lib": "./lib"
-	},
-	"dependencies": {
-		"async": "1.5.2",
-		"moment": "2.11.2",
-		"node-appc": "~0.2.35",
-		"node-uuid": "1.4.7",
-		"wrench": "1.5.8",
-		"xmldom": "0.1.22"
-	},
-	"devDependencies": {
-		"mocha": "*",
-		"should": "~7.1.1"
-	},
-	"scripts": {
-		"test": "mocha --require test/init --reporter spec --check-leaks test/",
-		"test-assemblies": "mocha --require test/init --reporter spec --check-leaks test/test-assemblies",
-		"test-certs": "mocha --require test/init --reporter spec --check-leaks test/test-certs",
-		"test-device": "mocha --require test/init --reporter spec --check-leaks test/test-device",
-		"test-emulator": "mocha --require test/init --reporter spec --check-leaks test/test-emulator",
-		"test-env": "mocha --require test/init --reporter spec --check-leaks test/test-env",
-		"test-logrelay": "mocha --require test/init --reporter spec --check-leaks test/test-logrelay",
-		"test-process": "mocha --require test/init --reporter spec --check-leaks test/test-process",
-		"test-visualstudio": "mocha --require test/init --reporter spec --check-leaks test/test-visualstudio",
-		"test-windowsphone": "mocha --require test/init --reporter spec --check-leaks test/test-windowsphone",
-		"test-winstore": "mocha --require test/init --reporter spec --check-leaks test/test-winstore",
-		"test-wptool": "mocha --require test/init --reporter spec --check-leaks test/test-wptool"
-	},
-	"os": [ "win32" ],
-	"engines": {
-		"node": ">=0.8"
-	}
+  "name": "windowslib",
+  "version": "0.4.23",
+  "description": "Windows Phone Utility Library",
+  "keywords": [
+    "appcelerator",
+    "windows",
+    "windows phone",
+    "winstore",
+    "windows store",
+    "visualstudio",
+    "visual studio",
+    "microsoft"
+  ],
+  "author": {
+    "name": "Appcelerator, Inc.",
+    "email": "npmjs@appcelerator.com"
+  },
+  "maintainers": [
+    {
+      "name": "Chris Barber",
+      "email": "cbarber@appcelerator.com"
+    },
+    {
+      "name": "Chris Williams",
+      "email": "cwilliams@appcelerator.com"
+    },
+    {
+      "name": "Dawson Toth",
+      "email": "dtoth@appcelerator.com"
+    },
+    {
+      "name": "Kota Iguchi",
+      "email": "kiguchi@appcelerator.com"
+    }
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/appcelerator/windowslib.git"
+  },
+  "license": "Apache Public License v2",
+  "main": "./index",
+  "bugs": {
+    "url": "https://github.com/appcelerator/windowslib/issues"
+  },
+  "directories": {
+    "lib": "./lib"
+  },
+  "dependencies": {
+    "async": "1.5.2",
+    "moment": "2.11.2",
+    "node-appc": "~0.2.35",
+    "uuid": "^3.0.0",
+    "wrench": "1.5.8",
+    "xmldom": "0.1.22"
+  },
+  "devDependencies": {
+    "mocha": "*",
+    "should": "~7.1.1"
+  },
+  "scripts": {
+    "test": "mocha --require test/init --reporter spec --check-leaks test/",
+    "test-assemblies": "mocha --require test/init --reporter spec --check-leaks test/test-assemblies",
+    "test-certs": "mocha --require test/init --reporter spec --check-leaks test/test-certs",
+    "test-device": "mocha --require test/init --reporter spec --check-leaks test/test-device",
+    "test-emulator": "mocha --require test/init --reporter spec --check-leaks test/test-emulator",
+    "test-env": "mocha --require test/init --reporter spec --check-leaks test/test-env",
+    "test-logrelay": "mocha --require test/init --reporter spec --check-leaks test/test-logrelay",
+    "test-process": "mocha --require test/init --reporter spec --check-leaks test/test-process",
+    "test-visualstudio": "mocha --require test/init --reporter spec --check-leaks test/test-visualstudio",
+    "test-windowsphone": "mocha --require test/init --reporter spec --check-leaks test/test-windowsphone",
+    "test-winstore": "mocha --require test/init --reporter spec --check-leaks test/test-winstore",
+    "test-wptool": "mocha --require test/init --reporter spec --check-leaks test/test-wptool"
+  },
+  "os": [
+    "win32"
+  ],
+  "engines": {
+    "node": ">=0.8"
+  }
 }


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.