### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+0.4.26 (12/20/2016)
+-------------------
+  * Use uuid instead of node-uuid
+
 0.4.25 (11/24/2016)
 -------------------
   * [TIMOB-23976] enumerate should just move on even when no results with given version

--- a/lib/logrelay.js
+++ b/lib/logrelay.js
@@ -16,7 +16,7 @@ const
 	EventEmitter = require('events').EventEmitter,
 	net = require('net'),
 	util = require('util'),
-	uuid = require('node-uuid'),
+	uuid = require('uuid'),
 	__ = appc.i18n(__dirname).__;
 
 module.exports = LogRelay;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "windowslib",
-	"version": "0.4.25",
+	"version": "0.4.26",
 	"description": "Windows Phone Utility Library",
 	"keywords": [
 		"appcelerator",
@@ -38,7 +38,7 @@
 		"async": "1.5.2",
 		"moment": "2.11.2",
 		"node-appc": "~0.2.35",
-		"node-uuid": "1.4.7",
+		"uuid": "3.0.0",
 		"wrench": "1.5.8",
 		"xmldom": "0.1.22"
 	},


### PR DESCRIPTION
Follow-up from #61. 
`node-uuid` got deprecated, we should use `uuid` instead for now.
