### PR TITLE
[TIMOB-24183] Failed to install WP 8.1 app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+0.4.27 (01/03/2017)
+-------------------
+  * [TIMOB-24183] Failed to install WP 8.1 app
+
 0.4.26 (12/20/2016)
 -------------------
   * Use uuid instead of node-uuid

--- a/lib/wptool.js
+++ b/lib/wptool.js
@@ -717,7 +717,7 @@ function nativeLaunch(device, appid, options, callback) {
 			// Here's where we expect the failure that the app is not installed, which is right.
 			// We're explicitly telling to launch a bogus app, so we expect a very specific failure as "success" here...
 			// if (code == -2146233088 || code == 2148734208)
-			if (errmsg.indexOf('The application is not installed.') != -1) {
+			if (errmsg == '' || errmsg.indexOf('The application is not installed.') != -1) {
 				// we must be successful, right?
 				callback(null, device);
 			} else {
@@ -758,7 +758,7 @@ function nativeInstall(deployCmd, device, appPath, options, callback) {
 	child.on('close', function (code) {
 		clearTimeout(abortTimer);
 
-		if (code) {
+		if (out.trim() != '' && code) {
 			var errmsg = out.trim().split(/\r\n|\n/).shift(),
 				ex = new Error(/^Error: /.test(errmsg) ? errmsg.substring(7) : __('Failed to install app (code %s)', code));
 			callback(ex);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "windowslib",
-	"version": "0.4.26",
+	"version": "0.4.27",
 	"description": "Windows Phone Utility Library",
 	"keywords": [
 		"appcelerator",


### PR DESCRIPTION
[TIMOB-24183](https://jira.appcelerator.org/browse/TIMOB-24183)

`appc run -p windows --target wp-device` fails to deploy apps to Windows Phone 8.1 device.

It turns out that deployment failed because outputs from Windows Phone deployment tools have been changed at some point of the installation, now it could output nothing but returns error code other than "0". As far as I can see it means deployment went successful and we can ignore the error code when output from tools are empty.

Note that this works with https://github.com/appcelerator/titanium_mobile_windows/pull/915 and you need to update windowslib in [titanium_mobile](https://github.com/appcelerator/titanium_mobile) in order to make this work.
