### PR TITLE
Use VsDevCmd instead of vcvarsall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+0.4.29 (03/14/2017)
+-------------------
+  * [TIMOB-24189] Use VsDevCmd instead of vcvarsall
+
 0.4.28 (02/27/2017)
 -------------------
   * [TIMOB-24189] Support Visual Studio 2017

--- a/lib/visualstudio.js
+++ b/lib/visualstudio.js
@@ -117,6 +117,7 @@ function detectVS2017Installations(emitter, options, callback) {
 				vsinfo.registryKey = null;
 				vsinfo.clrVersion  = null;
 				vsinfo.selected    = false;
+				vsinfo.vsDevCmd    = path.join(vsinfo.path, 'Common7', 'Tools', 'VsDevCmd.bat');
 
 				// Get the vcvarsall script
 				var vcvarsall = path.join(vsinfo.path, 'VC', 'Auxiliary', 'Build', 'vcvarsall.bat');
@@ -219,6 +220,9 @@ function detectInstallations(emitter, options, callback) {
 
 						// verify that this Visual Studio actually exists
 						if (info.path && fs.existsSync(info.path)) {
+
+							info.vsDevCmd = path.join(info.path, 'Common7', 'Tools', 'VsDevCmd.bat');
+
 							// get the vcvarsall script
 							var vcvarsall = path.join(info.path, 'VC', 'vcvarsall.bat');
 							if (fs.existsSync(vcvarsall)) {
@@ -379,9 +383,21 @@ function build(options, callback) {
 				callback: callback
 			} ];
 
-			appc.subprocess.run(vsInfo.vcvarsall.replace(/\ /g, '^ '), [ 'x86', 'store',
+			var p = spawn(vsInfo.vsDevCmd, [
 				'&&', 'MSBuild', '/t:rebuild', '/p:configuration=' + (options.buildConfiguration || 'Release'), options.project
-			], function (code, out, err) {
+			]), 
+			out = '',
+			err = '';
+
+			p.stdout.on('data', function(data) {
+				out += data.toString();
+			});
+
+			p.stderr.on('data', function(data) {
+				err += data.toString();
+			});
+
+			p.on('close', function (code) {
 				var queue = runningBuilds[options.project];
 				delete runningBuilds[options.project];
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "windowslib",
-	"version": "0.4.28",
+	"version": "0.4.29",
 	"description": "Windows Phone Utility Library",
 	"keywords": [
 		"appcelerator",

--- a/test/test-visualstudio.js
+++ b/test/test-visualstudio.js
@@ -57,7 +57,7 @@ describe('visualstudio', function () {
 
 function checkVisualStudio(visualstudio) {
 	should(visualstudio).be.an.Object;
-	should(visualstudio).have.keys('version', 'registryKey', 'supported', 'vcvarsall', 'msbuildVersion', 'wpsdk', 'selected', 'path', 'clrVersion');
+	should(visualstudio).have.keys('version', 'registryKey', 'supported', 'vcvarsall', 'msbuildVersion', 'wpsdk', 'selected', 'path', 'clrVersion', 'vsDevCmd');
 
 	should(visualstudio.version).be.a.String;
 	should(visualstudio.version).not.equal('');


### PR DESCRIPTION
[TIMOB-24189](https://jira.appcelerator.org/browse/TIMOB-24189)

I found interesting behavior while working on https://github.com/appcelerator/titanium_mobile_windows/pull/959, that is some VS batch tools (including `vcvarsall.bat`) does not work correctly when it is executed by [8.3 filenames](https://en.wikipedia.org/wiki/8.3_filename). We are usually using 8.3 filename when requiring `vcvarsall.bat` but it seems it does not work correctly under the situation. I'm also thinking that we should use `VsDevCmd.bat` instead because it's the file that Visual Studio Developer Console is using. We can safely replace it because  `VsDevCmd.bat` is available as of Visual Studio 2012.