### PR TITLE
Try to make wptool.connect poll emulator status and wait until it rep…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+0.5.0 (05/9/2017)
+-------------------
+  * Add emulator#status to get numeric status of emulator.
+  * Use status to poll emulator for running state (2) after launching but before installing app
+  * Add type property to object describing emulator or device, with value 'emulator' or 'device'
+  * re-use cached emulator listing inside emulator#isRunning and emulator#launch
+  * Fix winstore unit test to work with various version of Microsoft.Photos app
+
 0.4.30 (04/28/2017)
 -------------------
   * [TIMOB-24422] Windows: Fails to install dependencies for app on Windows 10 Phone Emulator

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,8 +2,7 @@
 library 'pipeline-library'
 
 timestamps {
-  // Tie to Win-Gin10 node fo rnow, otherwise install fails on WinGin02
-  node('windows && windows-sdk-10 && windows-sdk-8.1 && (vs2015 || vs2017) && npm-publish && Win-Gin10') {
+  node('windows && windows-sdk-10 && windows-sdk-8.1 && (vs2015 || vs2017) && npm-publish') {
     def packageVersion = ''
     def isPR = false
     stage('Checkout') {

--- a/bin/wp_emulator_enabledstate.ps1
+++ b/bin/wp_emulator_enabledstate.ps1
@@ -1,0 +1,25 @@
+# windowslib
+#
+# Tells Hyper-V to set the state to stopped. This script by itself cannot kill
+# a running Windows Phone emulator. It doesn't have the permissions to do so.
+# You should use "taskkill" to kill the "xde.exe" process which will cause the
+# emulator to close, but Hyper-V won't register that the emulator is stopped.
+# Run this script to let Hyper-V know you just killed the emulator.
+#
+# Copyright (c) 2014-2017 by Appcelerator, Inc. All Rights Reserved.
+# Licensed under the terms of the Apache Public License
+# Please see the LICENSE included with this distribution for details.
+
+if ($args.count -eq 0) {
+	echo '{"success": false, "message": "No Windows Phone emulator name specified"}'
+	exit 1
+}
+
+$query = "Select * from MSVM_Computersystem where Description like '%Virtual%'" + " AND ElementName like '" + $args[0] + ".%'"
+$vm = Get-WmiObject -computername localhost -NameSpace root\Virtualization\v2 -query $query
+
+if ($vm.__CLASS -eq 'Msvm_ComputerSystem') {
+	echo '{"success": true, "state": ' + $vm.EnabledState + ' }'
+} else {
+	echo '{"success": true, "message": "Not found or not running"}'
+}

--- a/bin/wp_emulator_enabledstate.ps1
+++ b/bin/wp_emulator_enabledstate.ps1
@@ -15,11 +15,11 @@ if ($args.count -eq 0) {
 	exit 1
 }
 
-$query = "Select * from MSVM_Computersystem where Description like '%Virtual%'" + " AND ElementName like '" + $args[0] + ".%'"
+$query = "Select * from MSVM_Computersystem where Description like '%Virtual%' AND ElementName like '" + $args[0] + ".%'"
 $vm = Get-WmiObject -computername localhost -NameSpace root\Virtualization\v2 -query $query
 
 if ($vm.__CLASS -eq 'Msvm_ComputerSystem') {
 	echo '{"success": true, "state": ' + $vm.EnabledState + ' }'
 } else {
-	echo '{"success": true, "message": "Not found or not running"}'
+	echo '{"success": false, "message": "Not found"}'
 }

--- a/bin/wp_emulator_enabledstate.ps1
+++ b/bin/wp_emulator_enabledstate.ps1
@@ -19,7 +19,7 @@ $query = "Select * from MSVM_Computersystem where Description like '%Virtual%' A
 $vm = Get-WmiObject -computername localhost -NameSpace root\Virtualization\v2 -query $query
 
 if ($vm.__CLASS -eq 'Msvm_ComputerSystem') {
-	echo '{"success": true, "state": ' + $vm.EnabledState + ' }'
+	echo "{""success"": true, ""state"": $($vm.EnabledState) }"
 } else {
 	echo '{"success": false, "message": "Not found"}'
 }

--- a/lib/emulator.js
+++ b/lib/emulator.js
@@ -446,7 +446,7 @@ function status(emuHandle, options, callback) {
 				'-ExecutionPolicy', 'Bypass', '-NoLogo', '-NonInteractive', '-NoProfile',
 				'-File',
 				psScript,
-				'"' + emuHandle.name + '"'
+				emuHandle.name
 			], function (code, out, err) {
 				console.log(out);
 				try {

--- a/lib/emulator.js
+++ b/lib/emulator.js
@@ -434,7 +434,6 @@ function status(emuHandle, options, callback) {
 				return callback(err);
 			}
 
-			console.log("Attempting to get ENabledState of emulator: " + emuHandle.name);
 			// next get hyper-v to think the emulator is not running
 			appc.subprocess.run(options.powershell || 'powershell', [
 				'-ExecutionPolicy', 'Bypass', '-NoLogo', '-NonInteractive', '-NoProfile',
@@ -442,7 +441,6 @@ function status(emuHandle, options, callback) {
 				psScript,
 				emuHandle.name
 			], function (code, out, err) {
-				console.log(out);
 				try {
 					if (!code) {
 						var result = JSON.parse(out);

--- a/lib/emulator.js
+++ b/lib/emulator.js
@@ -440,6 +440,7 @@ function status(emuHandle, options, callback) {
 				return callback(err);
 			}
 
+			console.log("Attempting to get ENabledState of emulator: " + emuHandle.name);
 			// next get hyper-v to think the emulator is not running
 			appc.subprocess.run(options.powershell || 'powershell', [
 				'-ExecutionPolicy', 'Bypass', '-NoLogo', '-NonInteractive', '-NoProfile',

--- a/lib/emulator.js
+++ b/lib/emulator.js
@@ -52,6 +52,10 @@ function detect(options, callback) {
 		}
 
 		wptool.enumerate(options, function (err, results) {
+			if (err) {
+				emitter.emit('error', err);
+				return callback(err);
+			}
 			var result = {
 				emulators: {},
 				issues: []
@@ -99,14 +103,23 @@ function isRunning(udid, options, callback) {
 					return callback(ex);
 				}
 
-				wptool.enumerate(options) // TODO USe detect so we can re-use the cache!
+				detect(options)
 					.on('error', function (err) {
 						emitter.emit('error', err);
 						callback(err);
 					})
 					.on('detected', function (results) {
+						var emu;
 						// find the emulator
-						var emu = results.getByUdid(udid);
+						function testDev(d) {
+							if (d.udid == udid) { // this MUST be == because the udid might be a number and not a string
+								emu = d;
+								return true;
+							}
+						};
+						Object.keys(results.emulators).some(function (wpsdk) {
+							return results.emulators[wpsdk].some(testDev);
+						});
 
 						if (!emu) {
 							var err = new Error(__('Invalid udid "%s"', udid));
@@ -171,8 +184,8 @@ function isRunning(udid, options, callback) {
  */
 function launch(udid, options, callback) {
 	return magik(options, callback, function (emitter, options, callback) {
-		// detect emulators // FIXME Use detect so we can re-use the cache!
-		wptool.enumerate(options, function (err, emuInfo) {
+		// detect emulators
+		detect(options, function (err, emuInfo) {
 			if (err) {
 				emitter.emit('error', err);
 				return callback(err);
@@ -185,7 +198,7 @@ function launch(udid, options, callback) {
 				Object.keys(emuInfo).filter(function (wpsdk) {
 					return !options.wpsdk || wpsdk === options.wpsdk;
 				}).some(function (wpsdk) {
-					return emuInfo[wpsdk].emulators.some(function (emu) {
+					return emuInfo.emulators[wpsdk].some(function (emu) {
 						if (emu.udid === udid) {
 							emuHandle = appc.util.mix({}, emu);
 							return true;
@@ -197,11 +210,11 @@ function launch(udid, options, callback) {
 					err = new Error(__('Unable to find an Windows Phone emulator with the UDID "%s"', udid));
 				}
 			} else {
-				Object.keys(emuInfo).filter(function (wpsdk) {
+				Object.keys(emuInfo.emulators).filter(function (wpsdk) {
 					return !options.wpsdk || wpsdk === options.wpsdk;
 				}).some(function (wpsdk) {
-					if (emuInfo[wpsdk].emulators.length) {
-						emuHandle = appc.util.mix({}, emuInfo[wpsdk].emulators[0]);
+					if (emuInfo.emulators[wpsdk].length) {
+						emuHandle = appc.util.mix({}, emuInfo.emulators[wpsdk][0]);
 						return true;
 					}
 				});

--- a/lib/emulator.js
+++ b/lib/emulator.js
@@ -368,14 +368,13 @@ function stop(emuHandle, options, callback) {
 						return callback(err);
 					}
 
-
 					var xdeRegExp = /^xde\.exe$/i,
 						name = emuHandle.name.toLowerCase();
 
 					async.eachSeries(processes, function (p, next) {
 						if (xdeRegExp.test(p.name) && p.title.toLowerCase() === name) {
 							// first kill the emulator
-							process.kill(p.pid, 'SIGKILL');
+							process.kill(p.pid, 'SIGKILL'); // FIXME If we get ESRCH, can we assume the process died on it's own?
 
 							setTimeout(function () {
 								// next get hyper-v to think the emulator is not running

--- a/lib/emulator.js
+++ b/lib/emulator.js
@@ -31,6 +31,7 @@ exports.isRunning = isRunning;
 exports.launch = launch;
 exports.install = install;
 exports.stop = stop;
+exports.status = status;
 
 /**
  * Detects connected Windows Phone emulators.
@@ -56,7 +57,7 @@ function detect(options, callback) {
 				emitter.emit('error', err);
 				return callback(err);
 			}
-			console.log(JSON.stringify(results));
+
 			var result = {
 				emulators: {},
 				issues: []

--- a/lib/emulator.js
+++ b/lib/emulator.js
@@ -99,11 +99,6 @@ function isRunning(udid, options, callback) {
 				callback(err);
 			})
 			.on('detected', function (results) {
-				if (!results.powershell.enabled) {
-					var ex = new Error(__('PowerShell scripts are disabled. Please change the execution policy to allow "RemoteSigned" scripts.'));
-					emitter.emit('error', ex);
-					return callback(ex);
-				}
 
 				detect(options)
 					.on('error', function (err) {

--- a/lib/emulator.js
+++ b/lib/emulator.js
@@ -447,6 +447,7 @@ function status(emuHandle, options, callback) {
 				psScript,
 				'"' + emuHandle.name + '"'
 			], function (code, out, err) {
+				console.log(out);
 				try {
 					if (!code) {
 						var re = new RegExp('^' + emuHandle.name + '\\..*(\\d+)(?:\\s+\\d+)$', 'i'),

--- a/lib/emulator.js
+++ b/lib/emulator.js
@@ -195,7 +195,7 @@ function launch(udid, options, callback) {
 
 			if (udid) {
 				// validate the udid
-				Object.keys(emuInfo).filter(function (wpsdk) {
+				Object.keys(emuInfo.emulators).filter(function (wpsdk) {
 					return !options.wpsdk || wpsdk === options.wpsdk;
 				}).some(function (wpsdk) {
 					return emuInfo.emulators[wpsdk].some(function (emu) {

--- a/lib/emulator.js
+++ b/lib/emulator.js
@@ -56,6 +56,7 @@ function detect(options, callback) {
 				emitter.emit('error', err);
 				return callback(err);
 			}
+			console.log(JSON.stringify(results));
 			var result = {
 				emulators: {},
 				issues: []

--- a/lib/emulator.js
+++ b/lib/emulator.js
@@ -399,3 +399,52 @@ function stop(emuHandle, options, callback) {
 		}, Date.now() - emuHandle.startTime < 250 ? 250 : 0);
 	});
 }
+
+/**
+ * Retrieves the status of the specified Windows Phone emulator.
+ *
+ * @param {Object} emuHandle - The emulator handle.
+ * @param {Object} [options] - An object containing various settings.
+ * @param {String} [options.powershell] - Path to the 'powershell' executable.
+ * @param {Boolean} [options.tasklist] - The path to the 'tasklist' executable.
+ * @param {Function} [callback(err)] - A function to call when the emulator has quit.
+ *
+ * @returns {EventEmitter}
+ */
+function status(emuHandle, options, callback) {
+	return magik(options, callback, function (emitter, options, callback) {
+		if (!emuHandle || typeof emuHandle !== 'object') {
+			var err = new Error(__('Invalid emulator handle argument'));
+			emitter.emit('error', err);
+			return callback(err);
+		}
+
+		appc.subprocess.getRealName(path.resolve(__dirname, '..', 'bin', 'wp_emulator_status.ps1'), function (err, psScript) {
+			if (err) {
+				emitter.emit('error', err);
+				return callback(err);
+			}
+
+			// next get hyper-v to think the emulator is not running
+			appc.subprocess.run(options.powershell || 'powershell', [
+				'-ExecutionPolicy', 'Bypass', '-NoLogo', '-NonInteractive', '-NoProfile',
+				'-File',
+				psScript,
+				'"' + emuHandle.name + '"'
+			], function (code, out, err) {
+				try {
+					if (!code) {
+						var re = new RegExp('^' + emuHandle.name + '\\..*(\\d+)(?:\\s+\\d+)$', 'i'),
+							match = out.trim().split(/\r\n|\n/).map(function (line) {
+								line = line.trim();
+								return line && line.match(re);
+							}).filter(function (m) { return !!m; }).shift(),
+							running = match && ~~match[1] === 2 || false;
+							return callback(null, match[1]);
+					}
+				} catch (e) {}
+				callback(new Error('Failed to retrieve emulator status'));
+			});
+		});
+	});
+}

--- a/lib/emulator.js
+++ b/lib/emulator.js
@@ -434,7 +434,7 @@ function status(emuHandle, options, callback) {
 			return callback(err);
 		}
 
-		appc.subprocess.getRealName(path.resolve(__dirname, '..', 'bin', 'wp_emulator_status.ps1'), function (err, psScript) {
+		appc.subprocess.getRealName(path.resolve(__dirname, '..', 'bin', 'wp_emulator_enabledstate.ps1'), function (err, psScript) {
 			if (err) {
 				emitter.emit('error', err);
 				return callback(err);
@@ -450,13 +450,12 @@ function status(emuHandle, options, callback) {
 				console.log(out);
 				try {
 					if (!code) {
-						var re = new RegExp('^' + emuHandle.name + '\\..*(\\d+)(?:\\s+\\d+)$', 'i'),
-							match = out.trim().split(/\r\n|\n/).map(function (line) {
-								line = line.trim();
-								return line && line.match(re);
-							}).filter(function (m) { return !!m; }).shift(),
-							running = match && ~~match[1] === 2 || false;
-							return callback(null, match[1]);
+						var result = JSON.parse(out);
+						if (result.success) {
+							return callback(null, result.state);
+						} else {
+							return callback(result.message);
+						}
 					}
 				} catch (e) {}
 				callback(new Error('Failed to retrieve emulator status'));

--- a/lib/wptool.js
+++ b/lib/wptool.js
@@ -620,8 +620,7 @@ function wpToolConnect(device, options, callback) {
 		try {
 			var result = JSON.parse(out),
 				pollEmulator;
-			console.log('Device: ' + JSON.stringify(device));
-			console.log('Connect result: ' + JSON.stringify(result));
+
 			if (!result.success) {
 				clearTimeout(abortTimer);
 				return callback(new Error(__('Failed to connect to %s', device.name)));
@@ -642,10 +641,8 @@ function wpToolConnect(device, options, callback) {
 							return callback(err);
 						}
 
-						console.log('Emulator status: ' + status);
 						if (status == 2) { // running state
 							clearTimeout(abortTimer);
-							console.log('Emulator is running! Let\'s kill the timeout, interval and mark it running and call the callback');
 							device.running = true; // mark it as running so we don't try and launch it again via connect
 							callback(null, device);
 						} else {
@@ -871,7 +868,7 @@ function wpToolInstall(deployCmd, device, appPath, options, callback) {
 
 		if (code) {
 			// handle duplicate package identity error code from Windows 10.0.14393 tooling and above
-			if (code == '2148734208' || code == '2147943860') {
+			if (code == '2148734208') {
 				if (out.indexOf('because the current user does not have that package installed') == -1) {
 					options.forceUnInstall = true;
 					wpToolInstall(deployCmd, device, appPath, options, callback);

--- a/lib/wptool.js
+++ b/lib/wptool.js
@@ -620,6 +620,8 @@ function wpToolConnect(device, options, callback) {
 			var result = JSON.parse(out),
 				intervalId,
 				pollEmulator;
+			console.log('Device: ' + JSON.stringify(device));
+			console.log('Connect result: ' + JSON.stringify(result));
 			if (!result.success) {
 				clearTimeout(abortTimer);
 				var ex = new Error(__('Failed to connect to %s', device.name));

--- a/lib/wptool.js
+++ b/lib/wptool.js
@@ -20,6 +20,7 @@ const
 	fs = require('fs'),
 	magik = require('./utilities').magik,
 	checkOutdated = require('./utilities').checkOutdated,
+	emulator = require('./emulator'),
 	path = require('path'),
 	spawn = require('child_process').spawn,
 	visualstudio = require('./visualstudio'),
@@ -95,7 +96,7 @@ function parseWinAppDeployCmdListing(out) {
 	while ((match = deviceListingRE.exec(out)) !== null)
 	{
 		// TODO How can we know what SDK is on the phone? My win 8.1U1 phone shows up in listings when connected via USB
-		devices.push({name: match[5], udid: match[3], index: i, wpsdk: null, ip: match[1]});
+		devices.push({name: match[5], udid: match[3], index: i, wpsdk: null, ip: match[1], type: 'device'});
 		i++;
 	}
 
@@ -197,7 +198,7 @@ function parseAppDeployCmdListing(out, wpsdk) {
 	var match;
 	while ((match = deviceListingRE.exec(out)) !== null)
 	{
-		emulators.push({name: match[2], udid: wpsdk.replace('.', '-') + "-" + match[1], index: parseInt(match[1]), wpsdk: wpsdk});
+		emulators.push({name: match[2], udid: wpsdk.replace('.', '-') + "-" + match[1], index: parseInt(match[1]), wpsdk: wpsdk, type: 'emulator'});
 	}
 
 	// TIMOB-19576
@@ -258,7 +259,7 @@ function nativeEnumerate(wpsdk, options, next) {
 			} else {
 				var emulators = parseAppDeployCmdListing(out, wpsdk);
 				next(null, {
-					devices: [{name: 'Device', udid: 0, index: 0, wpsdk: null}],
+					devices: [{name: 'Device', udid: 0, index: 0, wpsdk: null, type: 'device'}],
 					emulators: emulators
 				});
 			}
@@ -616,14 +617,33 @@ function wpToolConnect(device, options, callback) {
 		clearTimeout(abortTimer);
 
 		try {
-			var result = JSON.parse(out);
+			var result = JSON.parse(out),
+				intervalId,
+				pollEmulator;
 			if (!result.success) {
 				var ex = new Error(__('Failed to connect to %s', device.name));
 				return callback(ex);
 			}
 			device.ip = result.ip;
-			device.running = true; // mark it as running so we don't try and launch it again via connect
-			callback(null, device);
+			// If this is an emulator we should poll the status and wait until it's 'Running' before moving on
+			// I'm seeing consistent failures to install an app on Windows 10 emulators in our builds here.
+			if (device.type == 'emulator') {
+				pollEmulator = function() {
+					emulator.status(device, function(err, status) {
+						console.log('Emulator status: ' + status);
+						if (status == '2') {
+							clearInterval(intervalId);
+							device.running = true; // mark it as running so we don't try and launch it again via connect
+							callback(null, device);
+						}
+					});
+				};
+				intervalId = setInterval(pollEmulator, 500);
+			} else {
+				// It's a device, just assume we're ok
+				device.running = true; // mark it as running so we don't try and launch it again via connect
+				callback(null, device);
+			}
 		} catch (e) {
 			var ex = new Error(__('Failed to connect to %s', device.name));
 			callback(ex);

--- a/lib/wptool.js
+++ b/lib/wptool.js
@@ -125,6 +125,7 @@ function wptoolEnumerate(wpsdk, options, next) {
 		});
 
 		child.on('close', function (code) {
+			console.log('wptoolEnumerate output:' + out);
 			if (code) {
 				var errmsg = out.trim().split(/\r\n|\n/).shift(),
 					ex = new Error(/^Error: /.test(errmsg) ? errmsg.substring(7) : __('Failed to enumerate devices/emulators for WP SDK %s (code %s)', wpsdk, code));
@@ -139,6 +140,8 @@ function wptoolEnumerate(wpsdk, options, next) {
 		if (err) {
 			return next(err);
 		}
+
+		console.log("Windows Phone SDK detection results: " + JSON.stringify(phoneResults));
 
 		if (!phoneResults.windowsphone[wpsdk]) {
 			// Just move on if we have no results for a given version
@@ -173,6 +176,7 @@ function wptoolEnumerate(wpsdk, options, next) {
 			}
 		], function (err, results) {
 			if (err) {
+				console.error(err);
 				return next(err);
 			}
 			// Combine devices and emulators listings!
@@ -364,6 +368,7 @@ function enumerate(options, callback) {
 								emulators: [],
 							};
 						}
+						console.error(err);
 						errors.push(err);
 						next();
 					} else {

--- a/lib/wptool.js
+++ b/lib/wptool.js
@@ -621,6 +621,7 @@ function wpToolConnect(device, options, callback) {
 				intervalId,
 				pollEmulator;
 			if (!result.success) {
+				clearTimeout(abortTimer);
 				var ex = new Error(__('Failed to connect to %s', device.name));
 				return callback(ex);
 			}
@@ -632,6 +633,7 @@ function wpToolConnect(device, options, callback) {
 					emulator.status(device, function(err, status) {
 						console.log('Emulator status: ' + status);
 						if (status == '2') {
+							clearTimeout(abortTimer);
 							clearInterval(intervalId);
 							device.running = true; // mark it as running so we don't try and launch it again via connect
 							callback(null, device);
@@ -641,10 +643,12 @@ function wpToolConnect(device, options, callback) {
 				intervalId = setInterval(pollEmulator, 500);
 			} else {
 				// It's a device, just assume we're ok
+				clearTimeout(abortTimer);
 				device.running = true; // mark it as running so we don't try and launch it again via connect
 				callback(null, device);
 			}
 		} catch (e) {
+			clearTimeout(abortTimer);
 			var ex = new Error(__('Failed to connect to %s', device.name));
 			callback(ex);
 		}

--- a/lib/wptool.js
+++ b/lib/wptool.js
@@ -634,7 +634,8 @@ function wpToolConnect(device, options, callback) {
 				pollEmulator = function() {
 					emulator.status(device, function(err, status) {
 						console.log('Emulator status: ' + status);
-						if (status == '2') {
+						if (status == 2) { // running state
+							console.log('Emulator is running! Let\'s kill the timeout, interval and mark it running and call the callback');
 							clearTimeout(abortTimer);
 							clearInterval(intervalId);
 							device.running = true; // mark it as running so we don't try and launch it again via connect

--- a/lib/wptool.js
+++ b/lib/wptool.js
@@ -125,7 +125,6 @@ function wptoolEnumerate(wpsdk, options, next) {
 		});
 
 		child.on('close', function (code) {
-			console.log('wptoolEnumerate output:' + out);
 			if (code) {
 				var errmsg = out.trim().split(/\r\n|\n/).shift(),
 					ex = new Error(/^Error: /.test(errmsg) ? errmsg.substring(7) : __('Failed to enumerate devices/emulators for WP SDK %s (code %s)', wpsdk, code));
@@ -140,8 +139,6 @@ function wptoolEnumerate(wpsdk, options, next) {
 		if (err) {
 			return next(err);
 		}
-
-		console.log("Windows Phone SDK detection results: " + JSON.stringify(phoneResults));
 
 		if (!phoneResults.windowsphone[wpsdk]) {
 			// Just move on if we have no results for a given version
@@ -176,7 +173,6 @@ function wptoolEnumerate(wpsdk, options, next) {
 			}
 		], function (err, results) {
 			if (err) {
-				console.error(err);
 				return next(err);
 			}
 			// Combine devices and emulators listings!
@@ -368,7 +364,6 @@ function enumerate(options, callback) {
 								emulators: [],
 							};
 						}
-						console.error(err);
 						errors.push(err);
 						next();
 					} else {

--- a/lib/wptool.js
+++ b/lib/wptool.js
@@ -603,7 +603,8 @@ function wpToolConnect(device, options, callback) {
 		],
 		child = spawn(wptool, args),
 		out = '',
-		abortTimer;
+		abortTimer,
+		timedOut = false;
 
 	child.stdout.on('data', function (data) {
 		out += data.toString();
@@ -618,32 +619,41 @@ function wpToolConnect(device, options, callback) {
 
 		try {
 			var result = JSON.parse(out),
-				intervalId,
 				pollEmulator;
 			console.log('Device: ' + JSON.stringify(device));
 			console.log('Connect result: ' + JSON.stringify(result));
 			if (!result.success) {
 				clearTimeout(abortTimer);
-				var ex = new Error(__('Failed to connect to %s', device.name));
-				return callback(ex);
+				return callback(new Error(__('Failed to connect to %s', device.name)));
 			}
 			device.ip = result.ip;
 			// If this is an emulator we should poll the status and wait until it's 'Running' before moving on
 			// I'm seeing consistent failures to install an app on Windows 10 emulators in our builds here.
 			if (device.type == 'emulator') {
 				pollEmulator = function() {
+					if (timedOut) {
+						return;
+					}
+
+					// check if emulator is running...
 					emulator.status(device, function(err, status) {
+						if (err) {
+							clearTimeout(abortTimer);
+							return callback(err);
+						}
+
 						console.log('Emulator status: ' + status);
 						if (status == 2) { // running state
-							console.log('Emulator is running! Let\'s kill the timeout, interval and mark it running and call the callback');
 							clearTimeout(abortTimer);
-							clearInterval(intervalId);
+							console.log('Emulator is running! Let\'s kill the timeout, interval and mark it running and call the callback');
 							device.running = true; // mark it as running so we don't try and launch it again via connect
 							callback(null, device);
+						} else {
+							// try again in 500ms
+							setTimeout(pollEmulator, 500);
 						}
 					});
 				};
-				intervalId = setInterval(pollEmulator, 500);
 			} else {
 				// It's a device, just assume we're ok
 				clearTimeout(abortTimer);
@@ -652,12 +662,12 @@ function wpToolConnect(device, options, callback) {
 			}
 		} catch (e) {
 			clearTimeout(abortTimer);
-			var ex = new Error(__('Failed to connect to %s', device.name));
-			callback(ex);
+			callback(new Error(__('Failed to connect to %s', device.name)));
 		}
 	});
 	if (options.timeout) {
 		abortTimer = setTimeout(function () {
+			timedOut = true; // set flag so we don't poll on emulator state change
 			child.kill();
 
 			var ex = new Error(__('Timed out after %d milliseconds trying to connect to %s', options.timeout, device.name));

--- a/lib/wptool.js
+++ b/lib/wptool.js
@@ -654,6 +654,8 @@ function wpToolConnect(device, options, callback) {
 						}
 					});
 				};
+				// wait 250ms and check status of emulator
+				setTimeout(pollEmulator, 250);
 			} else {
 				// It's a device, just assume we're ok
 				clearTimeout(abortTimer);

--- a/lib/wptool.js
+++ b/lib/wptool.js
@@ -871,7 +871,7 @@ function wpToolInstall(deployCmd, device, appPath, options, callback) {
 
 		if (code) {
 			// handle duplicate package identity error code from Windows 10.0.14393 tooling and above
-			if (code == '2148734208') {
+			if (code == '2148734208' || code == '2147943860') {
 				if (out.indexOf('because the current user does not have that package installed') == -1) {
 					options.forceUnInstall = true;
 					wpToolInstall(deployCmd, device, appPath, options, callback);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "windowslib",
-	"version": "0.4.30",
+	"version": "0.5.0",
 	"description": "Windows Phone Utility Library",
 	"keywords": [
 		"appcelerator",

--- a/test/test-emulator.js
+++ b/test/test-emulator.js
@@ -197,8 +197,8 @@ describe('emulator', function () {
 		// We launch the emulator, but don't wait for it to be fully up before attempting to install the app.
 		// We should likely add some check that after we do wptool.connect we wait for the status to change to 'Running' from 'Starting'
 		// Add a specific test for this?
-		it('launch emulator and install app via install (from shut down emulator), then shutdown emulator', function (done) {
-			this.timeout(180000);
+		it('launch emulator and install app via #install (from shut down emulator), then shutdown emulator', function (done) {
+			this.timeout(240000);
 			this.slow(110000);
 
 			if (!emu) {

--- a/test/test-emulator.js
+++ b/test/test-emulator.js
@@ -135,9 +135,10 @@ describe('emulator', function () {
 
 			windowslib.emulator.detect(function (err, results) {
 				if (err) {
+					console.error(err);
 					return done(err);
 				}
-
+// FIXME Not getting the list of WIndows 10 emulators?
 				if (results.emulators[wpsdk].length > 0) {
 					emu = results.emulators[wpsdk][0];
 				}

--- a/test/test-emulator.js
+++ b/test/test-emulator.js
@@ -195,7 +195,7 @@ describe('emulator', function () {
 		// We launch the emulator, but don't wait for it to be fully up before attempting to install the app.
 		// We should likely add some check that after we do wptool.connect we wait for the status to change to 'Running' from 'Starting'
 		// Add a specific test for this?
-		it('launch emulator and install app via #install (from shut down emulator), skip launching app, then shutdown emulator', function (done) {
+		it('launch emulator and install app via #install (from shut down emulator), then shutdown emulator', function (done) {
 			this.timeout(240000);
 			this.slow(110000);
 
@@ -228,7 +228,7 @@ describe('emulator', function () {
 				},
 
 				function (next) {
-					windowslib.emulator.install(emu.udid, xapFile, { killIfRunning: true, wpsdk: wpsdk, skipLaunch: true }, function (err, _emuHandle) {
+					windowslib.emulator.install(emu.udid, xapFile, { killIfRunning: true, wpsdk: wpsdk }, function (err, _emuHandle) {
 						emuHandle = _emuHandle;
 						next(err);
 					});

--- a/test/test-emulator.js
+++ b/test/test-emulator.js
@@ -138,7 +138,7 @@ describe('emulator', function () {
 					console.error(err);
 					return done(err);
 				}
-// FIXME Not getting the list of WIndows 10 emulators?
+
 				if (results.emulators[wpsdk].length > 0) {
 					emu = results.emulators[wpsdk][0];
 				}

--- a/test/test-emulator.js
+++ b/test/test-emulator.js
@@ -111,16 +111,14 @@ describe('emulator', function () {
 		});
 	});
 
-	(process.platform === 'win32' ? it : it.skip)('should shutdown specified emulator', function (done) {
-		this.timeout(5000);
-		this.slow(4000);
-
-		windowslib.emulator.stop({
-			name: 'Some emulator that does not exist'
-		}, function () {
-			done();
-		});
-	});
+	// (process.platform === 'win32' ? it : it.skip)('should shutdown specified emulator', function (done) {
+	// 	this.timeout(5000);
+	// 	this.slow(4000);
+	//
+	// 	windowslib.emulator.stop({
+	// 		name: 'Some emulator that does not exist'
+	// 	}, done);
+	// });
 });
 
 [WIN_8, WIN_8_1, WIN_10].forEach(function (wpsdk) {
@@ -155,7 +153,7 @@ describe('emulator', function () {
 				return done();
 			}
 
-			windowslib.emulator.stop({ name: emu.name }, done);
+			windowslib.emulator.stop(emu, done);
 		});
 
 		it('launch and shutdown emulator', function (done) {
@@ -197,7 +195,7 @@ describe('emulator', function () {
 		// We launch the emulator, but don't wait for it to be fully up before attempting to install the app.
 		// We should likely add some check that after we do wptool.connect we wait for the status to change to 'Running' from 'Starting'
 		// Add a specific test for this?
-		it('launch emulator and install app via #install (from shut down emulator), then shutdown emulator', function (done) {
+		it('launch emulator and install app via #install (from shut down emulator), skip launching app, then shutdown emulator', function (done) {
 			this.timeout(240000);
 			this.slow(110000);
 
@@ -230,7 +228,7 @@ describe('emulator', function () {
 				},
 
 				function (next) {
-					windowslib.emulator.install(emu.udid, xapFile, { killIfRunning: true, wpsdk: wpsdk }, function (err, _emuHandle) {
+					windowslib.emulator.install(emu.udid, xapFile, { killIfRunning: true, wpsdk: wpsdk, skipLaunch: true }, function (err, _emuHandle) {
 						emuHandle = _emuHandle;
 						next(err);
 					});
@@ -254,7 +252,7 @@ describe('emulator', function () {
 			], done);
 		});
 
-		it('launch emulator, then install app via install, then shutdown emulator', function (done) {
+		it('launch emulator, then install and launch app via #install, then shutdown emulator', function (done) {
 			this.timeout(180000);
 			this.slow(110000);
 
@@ -330,7 +328,7 @@ describe('emulator', function () {
 			], done);
 		});
 
-		it('launch emulator, then install app via launch, then shutdown emulator', function (done) {
+		it('launch emulator, then install and launch app via #launch, then shutdown emulator', function (done) {
 			this.timeout(180000);
 			this.slow(110000);
 

--- a/test/test-winstore.js
+++ b/test/test-winstore.js
@@ -75,16 +75,25 @@ describe('winstore', function () {
 			// check multiline value, can't guarantee ordering of depencencies and sometimes ends with ...
 			// So we check start and ends with curly braces and contains specific depencencies we know
 			should(packages['Microsoft.Windows.Photos'].Dependencies).startWith('{').and.endWith('}');
-			if (packages['Microsoft.Windows.Photos'].Version === '17.313.10010.0') {
+
+			var photosVersion = packages['Microsoft.Windows.Photos'].Version;
+			if (photosVersion === '17.425.10010.0') {
+				should(packages['Microsoft.Windows.Photos'].Dependencies).containEql('Microsoft.VCLibs.140.00_14.0.24123.0_x64__8wekyb3d8bbwe');
+				should(packages['Microsoft.Windows.Photos'].Dependencies).containEql('Microsoft.NET.Native.Framework.1.3_1.3.24201.0_x64__8wekyb3d8bbwe');
+				should(packages['Microsoft.Windows.Photos'].Dependencies).containEql('Microsoft.NET.Native.Runtime.1.4_1.4.24201.0_x64__8wekyb3d8bbwe');
+				should(packages['Microsoft.Windows.Photos'].Dependencies).containEql('Microsoft.Windows.Photos_17.425.10010.0_neutral_split.scale-100_8wekyb3d8bbwe');
+			} else if (photosVersion === '17.313.10010.0') {
 				should(packages['Microsoft.Windows.Photos'].Dependencies).containEql('Microsoft.VCLibs.140.00_14.0.24123.0_x64__8wekyb3d8bbwe');
 				should(packages['Microsoft.Windows.Photos'].Dependencies).containEql('Microsoft.NET.Native.Framework.1.3_1.3.24201.0_x64__8wekyb3d8bbwe');
 				should(packages['Microsoft.Windows.Photos'].Dependencies).containEql('Microsoft.NET.Native.Runtime.1.3_1.3.23901.0_x64__8wekyb3d8bbwe');
 				should(packages['Microsoft.Windows.Photos'].Dependencies).containEql('Microsoft.Windows.Photos_17.313.10010.0_neutral_split.scale-100_8wekyb3d8bbwe');
-			} else {
+			} else if (photosVersion === '16.201.11370.0') {
 				should(packages['Microsoft.Windows.Photos'].Dependencies).containEql('Microsoft.VCLibs.140.00_14.0.22929.0_x64__8wekyb3d8bbwe');
 				should(packages['Microsoft.Windows.Photos'].Dependencies).containEql('Microsoft.NET.Native.Runtime.1.1_1.1.23406.0_x64__8wekyb3d8bbwe');
 				should(packages['Microsoft.Windows.Photos'].Dependencies).containEql('Microsoft.Windows.Photos_16.201.11370.0_neutral_split.scale-100_8wekyb3d8bbwe');
 				should(packages['Microsoft.Windows.Photos'].Dependencies).containEql('Microsoft.Windows.Photos_16.201.11370.0_neutral_split.scale-150_8wekyb3d8bbwe');
+			} else {
+				console.log('Unknown Microsoft.Photos app version, not attempting to verify dependency listing!');
 			}
 			done();
 		});

--- a/wptool/wptool.cs
+++ b/wptool/wptool.cs
@@ -114,6 +114,7 @@ namespace wptool
 						Console.WriteLine("\t\t\t\"index\": " + id + ",");
 						Console.WriteLine("\t\t\t\"version\": \"" + versionString + "\","); // windows 8.1: "6.3", windows 10: "10.0"
 						Console.WriteLine("\t\t\t\"wpsdk\": " + sdk);
+						Console.WriteLine("\t\t\t\"type\": \"device\"");
 						Console.Write("\t\t}");
 						j++;
 					}
@@ -139,6 +140,7 @@ namespace wptool
 						Console.WriteLine("\t\t\t\"version\": \"" + dev.Version + "\","); // 6.3 for 8.1 emulators, 6.4 for 10 emulators, 2147483647.2147483647.2147483647.2147483647 for device
 						Console.WriteLine("\t\t\t\"uapVersion\": \"" + dev.UapVersion + "\","); // blank/empty for 8.1 emulators and device, 10.0.10586.0 for win 10 emulators
 						Console.WriteLine("\t\t\t\"wpsdk\": \"" + wpsdk + "\"");
+						Console.WriteLine("\t\t\t\"type\": \"emulator\"");
 						Console.Write("\t\t}");
 						j++;
 					}

--- a/wptool/wptool.cs
+++ b/wptool/wptool.cs
@@ -113,7 +113,7 @@ namespace wptool
 						Console.WriteLine("\t\t\t\"udid\": " + id + ",");
 						Console.WriteLine("\t\t\t\"index\": " + id + ",");
 						Console.WriteLine("\t\t\t\"version\": \"" + versionString + "\","); // windows 8.1: "6.3", windows 10: "10.0"
-						Console.WriteLine("\t\t\t\"wpsdk\": " + sdk);
+						Console.WriteLine("\t\t\t\"wpsdk\": " + sdk + ","));
 						Console.WriteLine("\t\t\t\"type\": \"device\"");
 						Console.Write("\t\t}");
 						j++;
@@ -139,7 +139,7 @@ namespace wptool
 						Console.WriteLine("\t\t\t\"guid\": \"" + dev.Id + "\",");
 						Console.WriteLine("\t\t\t\"version\": \"" + dev.Version + "\","); // 6.3 for 8.1 emulators, 6.4 for 10 emulators, 2147483647.2147483647.2147483647.2147483647 for device
 						Console.WriteLine("\t\t\t\"uapVersion\": \"" + dev.UapVersion + "\","); // blank/empty for 8.1 emulators and device, 10.0.10586.0 for win 10 emulators
-						Console.WriteLine("\t\t\t\"wpsdk\": \"" + wpsdk + "\"");
+						Console.WriteLine("\t\t\t\"wpsdk\": \"" + wpsdk + "\",");
 						Console.WriteLine("\t\t\t\"type\": \"emulator\"");
 						Console.Write("\t\t}");
 						j++;

--- a/wptool/wptool.cs
+++ b/wptool/wptool.cs
@@ -113,7 +113,7 @@ namespace wptool
 						Console.WriteLine("\t\t\t\"udid\": " + id + ",");
 						Console.WriteLine("\t\t\t\"index\": " + id + ",");
 						Console.WriteLine("\t\t\t\"version\": \"" + versionString + "\","); // windows 8.1: "6.3", windows 10: "10.0"
-						Console.WriteLine("\t\t\t\"wpsdk\": " + sdk + ","));
+						Console.WriteLine("\t\t\t\"wpsdk\": " + sdk + ",");
 						Console.WriteLine("\t\t\t\"type\": \"device\"");
 						Console.Write("\t\t}");
 						j++;


### PR DESCRIPTION
…orts Running before callign callback. Need to add type property to emulator/device listings so we can determine at wptool level whether we are tryign to connect to device or emulator to toggle this behavior.