### PR TITLE
[TIMOB-24922] Fix cert generation on VS2017

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+0.5.1 (07/04/2017)
+-------------------
+  * [TIMOB-24922] Fix cert generation on VS2017 - Move to using vsDevCmd instead of vcvarsall
+  * [TIMOB-24668] Update VS2017 detection logic to prevent error with VS2015
 0.5.0 (05/9/2017)
 -------------------
   * Add emulator#status to get numeric status of emulator.

--- a/lib/certs.js
+++ b/lib/certs.js
@@ -89,7 +89,7 @@ function create(appid, certificateFile, options, callback) {
 				}
 
 				// first lets create the cert
-				appc.subprocess.run(vsInfo.vcvarsall.replace(/\ /g, '^ '), [
+				appc.subprocess.run(vsInfo.vsDevCmd.replace(/[ \(\)\&]/g, '^$&'), [
 					'&&',
 					options.powershell || 'powershell',
 					'-ExecutionPolicy', 'Bypass', '-NoLogo', '-NonInteractive', '-NoProfile',
@@ -221,7 +221,7 @@ function generate(subjectName, certificateFile, options, callback) {
 				'-e', expirationDate, '-sv', pvk, cer
 			];
 
-			appc.subprocess.run(vsInfo.vcvarsall.replace(/\ /g, '^ '), args, function (code, out, err) {
+			appc.subprocess.run(vsInfo.vsDevCmd.replace(/[ \(\)\&]/g, '^$&'), args, function (code, out, err) {
 				if (code) {
 					var ex = new Error(__('Failed to create certificate (code %s)', code));
 					emitter.emit('error', ex);
@@ -305,7 +305,7 @@ function generatePFX(privateKeyFile, certificateFile, pfxDestinationFile, passwo
 			}
 
 			// package the certificate as pfx
-			appc.subprocess.run(vsInfo.vcvarsall.replace(/\ /g, '^ '), args, function (code, out, err) {
+			appc.subprocess.run(vsInfo.vsDevCmd.replace(/[ \(\)\&]/g, '^$&'), args, function (code, out, err) {
 				if (code) {
 					var ex = new Error(__('Failed to convert certificate to pfx (code %s)', code));
 					emitter.emit('error', ex);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "windowslib",
-	"version": "0.5.0",
+	"version": "0.5.1",
 	"description": "Windows Phone Utility Library",
 	"keywords": [
 		"appcelerator",


### PR DESCRIPTION
JIRA: https://jira.appcelerator.org/browse/TIMOB-24922

On VS2017 the cert generation process errors due to using vcvarsall, switching to using vsDevCmd fixes this.

Tested on VS2017 and VS 2015

Verification

1. Build an application using `appc run -p windows -T dist-phonestore`
2. Follow the prompts
  - Cert should be created and packaging should be successful 