### PR TITLE
[TIMOB-24683] Do not attempt to run winappdeploycmd if it does not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+0.5.2 (07/12/2017)
+  * [TIMOB-246830] Do not attempt to run winappdeploycmd if it does not exist
 0.5.1 (07/04/2017)
 -------------------
   * [TIMOB-24922] Fix cert generation on VS2017 - Move to using vsDevCmd instead of vcvarsall

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 0.5.2 (07/12/2017)
-  * [TIMOB-246830] Do not attempt to run winappdeploycmd if it does not exist
+  * [TIMOB-24683] Do not attempt to run winappdeploycmd if it does not exist
+  * [TIMOB-24956] Fix issue where temporary AppxManifest would not get written when fetching project guid
 0.5.1 (07/04/2017)
 -------------------
   * [TIMOB-24922] Fix cert generation on VS2017 - Move to using vsDevCmd instead of vcvarsall

--- a/lib/wptool.js
+++ b/lib/wptool.js
@@ -149,7 +149,11 @@ function wptoolEnumerate(wpsdk, options, next) {
 		async.parallel([
 			// discover windows 10 devices in network using WinAppDeployCmd
 			function (cb) {
-				winAppDeployCmdEnumerate(phoneResults.windowsphone[wpsdk].deployCmd, cb);
+				if (phoneResults.windowsphone[wpsdk].deployCmd) {
+					winAppDeployCmdEnumerate(phoneResults.windowsphone[wpsdk].deployCmd, cb);
+				} else {
+					cb();
+				}
 			},
 			// Use our custom wptool binary to gather Windows 10 emulators
 			function (cb) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "windowslib",
-	"version": "0.5.1",
+	"version": "0.5.2",
 	"description": "Windows Phone Utility Library",
 	"keywords": [
 		"appcelerator",


### PR DESCRIPTION
JIRA: https://jira.appcelerator.org/browse/TIMOB-24683

It looks like in VS2017 it is possible to install a Windows 10 SDK and there not be a winappdeploycmd (or VS is still not great at uninstalling cleanly). So if the deploycmdproperty does not exist don't try and detect devices

## Verification

See jira