### PR TITLE
[TIMOB-24958] Fix detection of SDK specific winappdeploycmd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+0.5.4 (08/15/2017)
+  * [TIMOB-24958] Fix detection of SDK specific winappdeploycmd
 0.5.3 (08/09/2017)
   * [TIMOB-24683] Must call the callback with an object like {devices:[], emulator:[]}
 0.5.2 (07/12/2017)

--- a/lib/windowsphone.js
+++ b/lib/windowsphone.js
@@ -155,10 +155,19 @@ function detectWin10(options, callback) {
 								sdks: []
 							};
 
-							var deployCmd = path.join(parts[2], 'bin', 'x86', 'WinAppDeployCmd.exe'),
-								signTool = path.join(parts[2], 'bin', 'x86', 'signtool.exe');
+							var binDir = path.join(parts[2], 'bin'),
+								deployCmd = path.join(binDir, 'x86', 'WinAppDeployCmd.exe'),
+								signTool = path.join(binDir, 'x86', 'signtool.exe');
 							if (fs.existsSync(deployCmd)) {
 								results.windowsphone[version].deployCmd = deployCmd;
+							}
+							var dirs = fs.readdirSync(binDir).filter(dirname => /(\d+\.\d+\.\d+)\.\d+/.test(dirname));
+							for (var i = 0; i < dirs.length; i++) {
+								var sdk = dirs[i];
+								deployCmd = path.join(binDir, sdk, 'x86', 'WinAppDeployCmd.exe')
+								if (fs.existsSync(deployCmd)) {
+									results.windowsphone[version].deployCmd = deployCmd;
+								}
 							}
 							if (fs.existsSync(signTool)) {
 								results.windowsphone[version].xapSignTool = signTool;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "windowslib",
-	"version": "0.5.3",
+	"version": "0.5.4",
 	"description": "Windows Phone Utility Library",
 	"keywords": [
 		"appcelerator",


### PR DESCRIPTION
JIRA: https://jira.appcelerator.org/browse/TIMOB-24958

After detecting the 'globally installed' winappdeploycmd,
- Search through the bin directory for folders that match a regex  for the 10 SDK. 
- Search the bin\x86 folder of each SDK for winappdeploycmd.exe

This means that we moving forward we will take the highest version of the tool on the system (also just to call out what the differences are the one under 10.0.15063 has a -preserveAppData flag which might be useful for us).

For example: 
- VS 2017 with only 10.0.15063.0 will take the winappdeploycmd under `C:\Program Files (x86)\Windows Kits\10\bin\10.0.15063.0\x86`
- VS 2017 with 10.0.15063.0 and 10.0.14393.0 will take the winappdeploycmd under `C:\Program Files (x86)\Windows Kits\10\bin\10.0.15063.0\x86`
- VS 2017 with only 10.0.14393.0 will take the winappdeploycmd under `C:\Program Files (x86)\Windows Kits\10\bin\x86`
- VS 2015 with 10.0.15063.0 (manually installed) and 10.0.14393.0 will take the winappdeploycmd under `C:\Program Files (x86)\Windows Kits\10\bin\10.0.15063.0\x86` (although we cannot build with this SDK, the tooling underneath works just fine)
-   VS 2015 with only 10.0.14393.0 will take the winappdeploycmd under `C:\Program Files (x86)\Windows Kits\10\bin\x86`

## Verification

1. Test building to Windows 10 devices
2. Test `ti info` (and Studio) can detect Windows 10 devices
