### PR TITLE
Use node_js image on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
-language: c#
+language: node_js
 sudo: false
-install:
-- npm install
-script:
-- npm test
+node_js:
+- '4'
+- '6'
+- '8'
 deploy:
   provider: npm
   email: npmjs@appcelerator.com


### PR DESCRIPTION
The c# image gave us nothing over the node_js image (they both run the same number of tests) and this allows us to check our code against a range of node versions (plus it actually works)