### PR TITLE
[TIMOB-25232] Make sure to catch JSON.parse errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+0.5.5 (09/07/2017)
+  * [TIMOB-25232] Make sure to catch JSON.parse errors
 0.5.4 (08/15/2017)
   * [TIMOB-24958] Fix detection of SDK specific winappdeploycmd
 0.5.3 (08/09/2017)

--- a/lib/visualstudio.js
+++ b/lib/visualstudio.js
@@ -62,7 +62,11 @@ function runVS2017Tool(next) {
 				]
 			});
 		} else {
-			next(null, JSON.parse(out));
+			try {
+				next(null, JSON.parse(out));
+			} catch (E) {
+				next(null, {});
+			}
 		}
 	});
 }

--- a/lib/wptool.js
+++ b/lib/wptool.js
@@ -130,7 +130,11 @@ function wptoolEnumerate(wpsdk, options, next) {
 					ex = new Error(/^Error: /.test(errmsg) ? errmsg.substring(7) : __('Failed to enumerate devices/emulators for WP SDK %s (code %s)', wpsdk, code));
 				next(ex, null);
 			} else {
-				next(null, JSON.parse(out));
+				try {
+					next(null, JSON.parse(out));
+				} catch (E) {
+					next(null, {});
+				}
 			}
 		});
 	}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "windowslib",
-	"version": "0.5.4",
+	"version": "0.5.5",
 	"description": "Windows Phone Utility Library",
 	"keywords": [
 		"appcelerator",


### PR DESCRIPTION
[TIMOB-25232](https://jira.appcelerator.org/browse/TIMOB-25232)

I was not able to reproduce this particular issue, but we need to make sure `JSON.parse` not throw error when enumerating environmental information.