### PR TITLE
[DAEMON-165] Handle max path when building wptool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+0.6.1 (21/11/2017)
+  * [DAEMON-165] Handle max path when building wptool
 0.6.0 (08/30/2017)
   * [TIMOB-25027] Only detect emulators based off the optional supportedWindowsPhoneSDKVersions parameter
   * Add coverage gathering

--- a/lib/wptool.js
+++ b/lib/wptool.js
@@ -28,6 +28,11 @@ const
 	wrench = require('wrench'),
 	wptool = path.resolve(__dirname, '..', 'bin', 'wptool.exe'),
 	__ = appc.i18n(__dirname).__,
+	os = require('os'),
+	
+	// Temp build directory to build the wptool in if the path is too long
+	// to copy the .dll files into
+	tmpBuildDir = path.join(os.tmpdir(), 'appcelerator', 'wptool'),
 
 	// this is a hard coded list of emulators to detect.
 	// when the next windows phone is released, the enumerate()
@@ -576,6 +581,22 @@ function buildWpTool(options, callback) {
 		fs.existsSync(d = path.resolve(__dirname, '..', 'wptool', 'bin')) && wrench.rmdirSyncRecursive(d);
 		fs.existsSync(d = path.resolve(__dirname, '..', 'wptool', 'obj')) && wrench.rmdirSyncRecursive(d);
 
+		var pathLength = 0;
+		for(var assembly of Object.keys(requiredAssemblies)) {
+			var assemblyPath = path.join(__dirname,'wptool', 'bin', 'Release' , assembly);
+			if (assemblyPath.length > pathLength) {
+				pathLength = assemblyPath.length;
+			}
+		}
+		if (pathLength >= 260) {
+			if (!fs.existsSync(tmpBuildDir)) {
+				wrench.mkdirSyncRecursive(tmpBuildDir);
+			}
+			wrench.copyDirSyncRecursive(path.join(__dirname, '..', 'wptool'), tmpBuildDir, {
+				forceDelete: true
+			});
+			project = path.join(tmpBuildDir, 'wptool.csproj');
+		}
 		// build the wptool
 		visualstudio.build(appc.util.mix({
 			buildConfiguration: 'Release',
@@ -585,7 +606,8 @@ function buildWpTool(options, callback) {
 				return callback(err);
 			}
 
-			var src = path.resolve(__dirname, '..', 'wptool', 'bin', 'Release', 'wptool.exe');
+			var src = path.resolve(path.dirname(project), 'bin', 'Release', 'wptool.exe');
+
 			if (!fs.existsSync(src)) {
 				var ex = new Error(__('Failed to build the wptool executable.'));
 				return callback(ex);
@@ -595,7 +617,7 @@ function buildWpTool(options, callback) {
 			fs.writeFileSync(wptool, fs.readFileSync(src));
 
 			// Make sure to copy all dependencies
-			var srcdir = path.resolve(__dirname, '..', 'wptool', 'bin', 'Release');
+			var srcdir = path.resolve(path.dirname(project), 'bin', 'Release');
 			fs.readdirSync(srcdir).forEach(function(filename) {
 				if (path.extname(filename) == '.dll') {
 					var dest = path.resolve(__dirname, '..', 'bin', filename);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "windowslib",
-	"version": "0.6.0",
+	"version": "0.6.1",
 	"description": "Windows Phone Utility Library",
 	"keywords": [
 		"appcelerator",


### PR DESCRIPTION
If the total path length of ``__dirname\wptool\bin\Release\<longest_assembly_name>`` is greater than or equal to max path, then we will move the wptool project to os.tmpDir() and build there..

~~I'm still trying to decide on a best course of action if the ``__dirname\bin`` directory proves too long to copy to, as we will have to consider this when calling checkOutdated too~~

Edit: The above is unecessary, a user with the max allowed username does not trigger an error copying the files to bin