### PR TITLE
[TIMOB-25616] Don't forceUnInstall unless user explicitly specifies it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+0.6.3 (19/12/2017)
+  * [TIMOB-25616] Don't forceUnInstall unless user explicitly specifies it
 0.6.3 (27/11/2017)
   * [DAEMON-184] Remove unnecessary quote when building project
 0.6.2 (27/11/2017)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-0.6.3 (19/12/2017)
+0.6.4 (19/12/2017)
   * [TIMOB-25616] Don't forceUnInstall unless user explicitly specifies it
 0.6.3 (27/11/2017)
   * [DAEMON-184] Remove unnecessary quote when building project

--- a/lib/wptool.js
+++ b/lib/wptool.js
@@ -907,7 +907,7 @@ function wpToolInstall(deployCmd, device, appPath, options, callback) {
 					if (options.forceUnInstall) {
 						wpToolInstall(deployCmd, device, appPath, options, callback);
 					} else {
-						callback(new Error('A debug application is already installed. Please remove existing debug application, or use forceUnInstall option to explicitly delete existing app.'));
+						callback(new Error('A debug application is already installed. Please increment the version number of the application, or use forceUnInstall option to explicitly delete existing app.'));
 					}
 				} else {
 					// Windows cannot remove the app because the current user does not have that package installed.
@@ -931,7 +931,7 @@ function wpToolInstall(deployCmd, device, appPath, options, callback) {
 						// Provided package has the same identity as an already-installed package. Proceed uninstalling.
 						wpToolInstall(deployCmd, device, appPath, options, callback);
 					} else {
-						callback(new Error('A debug application is already installed. Please remove existing debug application, or use forceUnInstall option to explicitly delete existing app.'));
+						callback(new Error('A debug application is already installed. Please increment the version number of the application, or use forceUnInstall option to explicitly delete existing app.'));
 					}
 				} else {
 					callback(new Error(__('Failed to install app (code %s): %s', err, msg)));

--- a/lib/wptool.js
+++ b/lib/wptool.js
@@ -904,8 +904,11 @@ function wpToolInstall(deployCmd, device, appPath, options, callback) {
 			// handle duplicate package identity error code from Windows 10.0.14393 tooling and above
 			if (code == '2148734208') {
 				if (out.indexOf('because the current user does not have that package installed') == -1) {
-					options.forceUnInstall = true;
-					wpToolInstall(deployCmd, device, appPath, options, callback);
+					if (options.forceUnInstall) {
+						wpToolInstall(deployCmd, device, appPath, options, callback);
+					} else {
+						callback(new Error('A debug application is already installed. Please remove existing debug application, or use forceUnInstall option to explicitly delete existing app.'));
+					}
 				} else {
 					// Windows cannot remove the app because the current user does not have that package installed.
 					callback(new Error('A debug application is already installed, please remove existing debug application'));
@@ -924,9 +927,12 @@ function wpToolInstall(deployCmd, device, appPath, options, callback) {
 				if (err == '0x80073CF9') {
 					callback(new Error('A debug application is already installed, please remove existing debug application'));
 				} else if (err == '0x80073CFB') {
-					// Provided package has the same identity as an already-installed package. Proceed uninstalling.
-					options.forceUnInstall = true;
-					wpToolInstall(deployCmd, device, appPath, options, callback);
+					if (options.forceUnInstall) {
+						// Provided package has the same identity as an already-installed package. Proceed uninstalling.
+						wpToolInstall(deployCmd, device, appPath, options, callback);
+					} else {
+						callback(new Error('A debug application is already installed. Please remove existing debug application, or use forceUnInstall option to explicitly delete existing app.'));
+					}
 				} else {
 					callback(new Error(__('Failed to install app (code %s): %s', err, msg)));
 				}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "windowslib",
-	"version": "0.6.3",
+	"version": "0.6.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "windowslib",
-	"version": "0.6.3",
+	"version": "0.6.4",
 	"description": "Windows Phone Utility Library",
 	"keywords": [
 		"appcelerator",


### PR DESCRIPTION
[TIMOB-25616](https://jira.appcelerator.org/browse/TIMOB-25616)

Windowslib have been uninstalling existing app in order to complete the installation when same version of the app is already installed, but we should not uninstall existing app unless user explicitly specifies `forceUnInstall`option. It should ends up showing error message when `forceUnInstall=false` and there's same version of the app installed, which should be the default behavior of `wpToolInstall`.