### PR TITLE
[TIMOB-25827] Error when fresh install with forceUnInstall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+0.6.5 (02/03/2018)
+  * [TIMOB-25827] Fix error when fresh install with forceUnInstall 
 0.6.4 (19/12/2017)
   * [TIMOB-25616] Don't forceUnInstall unless user explicitly specifies it
 0.6.3 (27/11/2017)

--- a/lib/wptool.js
+++ b/lib/wptool.js
@@ -903,7 +903,10 @@ function wpToolInstall(deployCmd, device, appPath, options, callback) {
 		if (code) {
 			// handle duplicate package identity error code from Windows 10.0.14393 tooling and above
 			if (code == '2148734208') {
-				if (out.indexOf('because the current user does not have that package installed') == -1) {
+				if (out.indexOf('0x80131500 - Failed to install or update package: Unspecified error') != -1) {
+					// handle duplicate package identity error code from Windows 10.0.14393 tooling and above
+					callback(new Error('A debug application is already installed, please remove existing debug application.'));
+				} else if (out.indexOf('because the current user does not have that package installed') == -1) {
 					if (options.forceUnInstall) {
 						wpToolInstall(deployCmd, device, appPath, options, callback);
 					} else {
@@ -911,7 +914,8 @@ function wpToolInstall(deployCmd, device, appPath, options, callback) {
 					}
 				} else {
 					// Windows cannot remove the app because the current user does not have that package installed.
-					callback(new Error('A debug application is already installed, please remove existing debug application'));
+					options.forceUnInstall = false;
+					wpToolInstall(deployCmd, device, appPath, options, callback);
 				}
 			} else {
 				var errmsg = out.trim().split(/\r\n|\n/).shift(),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "windowslib",
-	"version": "0.6.4",
+	"version": "0.6.5",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "windowslib",
-	"version": "0.6.4",
+	"version": "0.6.5",
 	"description": "Windows Phone Utility Library",
 	"keywords": [
 		"appcelerator",


### PR DESCRIPTION
[TIMOB-25827](https://jira.appcelerator.org/browse/TIMOB-25827)

Expected:

1. Build an application for wp-emulator with the emulator closed (clean state) with `--forceUnInstall`
2. Build should not fail

Also make sure [TIMOB-23800](https://jira.appcelerator.org/browse/TIMOB-23800) doesn't happen again

1. Build an application
2. Without uninstalling an app, build an app with same `<guid>` with different `<id>` in `tiapp.xml`
3. Build should error out with `A debug application is already installed, please remove existing debug application.`
4. After uninstalling an app manually, build should not fail then.
