### PR TITLE
[CVE-2017-18214] Fix potential security vulnerability in moment

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
 	},
 	"dependencies": {
 		"async": "1.5.2",
-		"moment": "2.11.2",
+		"moment": "2.19.3",
 		"node-appc": "~0.2.35",
 		"uuid": "3.0.0",
 		"wrench": "1.5.8",


### PR DESCRIPTION
github recently alerted [potential security vulnerability in dependencies in moment package before 2.19.3](https://nvd.nist.gov/vuln/detail/CVE-2017-18214). I believe this has to be small impact for windowslib because no dates are generated from strings but I would like to suppress the warning.