### PR TITLE
fix(certs): double callback on thumbprint

### DIFF
--- a/lib/certs.js
+++ b/lib/certs.js
@@ -131,16 +131,16 @@ function create(appid, certificateFile, options, callback) {
  * @param {Function} [callback(err, thumbprint)] - A function to call after the thumbprint has been extracted.
  */
 function parseCertUtilOutput(certificateFile, out, callback) {
+	var thumbprint;
 	if (out.indexOf('The system cannot find the file specified.') >= 0) {
-		callback(new Error('No certificate was found at the path: "' + certificateFile + '"'));
+		return callback(new Error('No certificate was found at the path: "' + certificateFile + '"'));
 	}
-	else {
-		try {
-			callback(null, out.split('(sha1): ')[1].split('\r')[0].split(' ').join('').toUpperCase());
-		} catch (E) {
-			callback(new Error('Unexpected output: ' + E.toString() + '\n' + out));
-		}
+	try {
+		thumbprint = out.split('(sha1): ')[1].split('\r')[0].split(' ').join('').toUpperCase();
+	} catch (E) {
+		return callback(new Error('Unexpected output: ' + E.toString() + '\n' + out));
 	}
+	callback(null, thumbprint);
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "windowslib",
-	"version": "0.6.8",
+	"version": "0.6.9",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "windowslib",
-	"version": "0.6.8",
+	"version": "0.6.9",
 	"description": "Windows Phone Utility Library",
 	"keywords": [
 		"appcelerator",

--- a/test/test-certs.js
+++ b/test/test-certs.js
@@ -75,6 +75,41 @@ describe('certs', function () {
 		});
 	});
 
+	it('parseCertUtilOutput() does not call callback twice if consumer throws Error', function (done) {
+		var output = "Certificates: Not Encrypted\r\n" +
+			"================ Certificate 0 ================\r\n" +
+			"================ Begin Nesting Level 1 ================\r\n" +
+			"Element 0:\r\n" +
+			"Serial Number: ae0bba023dbbe5ac42782735199df0fc\r\n" +
+			"Issuer: CN=CMake Test Cert\r\n" +
+			" NotBefore: 1/1/2014 3:00 AM\r\n" +
+			" NotAfter: 1/1/2100 3:00 AM\r\n" +
+			"Subject: CN=CMake Test Cert\r\n" +
+			"Signature matches Public Key\r\n" +
+			"Root Certificate: Subject matches Issuer\r\n" +
+			"Cert Hash(sha1): f6 3a ac 84 a0 88 4c db 01 26 c3 cd ea 99 1e 36 df 06 4b 3e\r\n" +
+			"----------------  End Nesting Level 1  ----------------\r\n" +
+			"  Provider = Microsoft Strong Cryptographic Provider\r\n" +
+			"Signature test passed\r\n" +
+			"CertUtil: -dump command completed successfully..";
+		var failed = false;
+		var callCount = 0;
+		should.throws(function () {
+			windowslib.certs.test.parseCertUtilOutput(CERT_FILE, output, function (err, value) {
+				callCount++;
+				// first time we're called, throw an Error
+				if (!failed) {
+					failed = true;
+					throw new Error('consumer throwing error');
+				}
+				if (callCount > 1) {
+					return done(new Error('Callback for parseCertUtilOutput got called twice!'));
+				}
+			});
+		}, /consumer throwing error/);
+		done();
+	});
+
 	(process.platform === 'win32' ? it : it.skip)('thumbprint retrieves sha1 thumbprint of cmake temp key with no password', function (done) {
 		this.timeout(5000);
 		this.slow(4000);


### PR DESCRIPTION
if the consuming code throws an error in it's callback handler, the thumbprint method could call the callback twice.

This fixes that behavior and adds a test to verify the fix.